### PR TITLE
core-permissions-1: Implement REQ-LAZY-0005 permission mapping + env overrides

### DIFF
--- a/dev-docs/review/_artifacts/traceability.csv
+++ b/dev-docs/review/_artifacts/traceability.csv
@@ -1,5 +1,5 @@
 SourceID,Description,MappedTo,ImplementationRefs,Evidence,Status
-REQ-LAZY-0005,"非交互权限映射（default/plan/acceptEdits/bypassPerms）",CODEX-CLI-0001;CODEX-CLI-0002;CODEX-CLI-0003,"acp-lazy-core/src/permissions.rs:89-108 (map_acp_to_codex)","dev-docs/review/_artifacts/logs/test_20250902_*.log",Verified
+REQ-LAZY-0005,"非交互权限映射（default/plan/acceptEdits/bypassPerms）",CODEX-CLI-0001;CODEX-CLI-0002;CODEX-CLI-0003,"acp-lazy-core/src/permissions.rs:99-118 (map_acp_to_codex); permissions.rs:173-185 (PermissionOverrides::apply)","dev-docs/review/_artifacts/logs/core_permissions_test_20250902_*.log",Verified
 REQ-LAZY-0001,"ACP 基线方法实现（stdio JSONL）",SPEC-ACP-METHODS-0002;SPEC-ACP-STREAM-0003;SPEC-ACP-CANCEL-0008,"acp-lazy-core/src/protocol.rs (Request/Response/Notification types)",,Partial
 ARC-LAZY-0001,"transport 行级读写与队列",SPEC-ACP-CONSTRAINTS-0005,"acp-lazy-core/src/transport.rs:161-196 (read_lines); acp-lazy-core/src/transport.rs:201-221 (write_line)","dev-docs/review/_artifacts/logs/test_20250902_*.log",Verified
 SPEC-ACP-JSONRPC-0001,"JSON-RPC 2.0 错误码",REQ-LAZY-0001,"acp-lazy-core/src/protocol.rs:13-39 (ErrorCode enum)","dev-docs/review/_artifacts/logs/test_20250902_*.log",Verified


### PR DESCRIPTION
Summary - Implements and verifies REQ-LAZY-0005 (permissions module) - Permission mode mappings:   - default/plan → {never, read-only, false}   - acceptEdits → {never, workspace-write, false}   - bypassPerms → {never, workspace-write, true}   - YOLO → {never, danger-full-access, true} + --dangerously-bypass-approvals-and-sandbox - Environment variable overrides with prefix ACPLB - No memory leaks (using Cow<'static, str>) - Comprehensive tests  Tests/Evidence - 5 permission tests passing - Evidence logs: dev-docs/review/_artifacts/logs/core_permissions_test_20250902_*.log  Tech details - Branch: feature/core-permissions-1 - Commit: 61da0d9 - Base: main - Workflow: worktree-first; branch already pushed  Traceability - Satisfies: REQ-LAZY-0005