### PR TITLE
codex-tools-1: ACP v1 alignment & tool call integration (scoped)

### DIFF
--- a/crates/codex-cli-acp/src/codex_proto.rs
+++ b/crates/codex-cli-acp/src/codex_proto.rs
@@ -2,15 +2,20 @@
 //!
 //! This module handles parsing and mapping of Codex native proto events to ACP events.
 
+use crate::tool_calls::{
+    extract_shell_command, extract_shell_params, format_tool_output, map_tool_kind,
+    MAX_OUTPUT_PREVIEW_BYTES,
+};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace};
 
 /// Codex proto event types
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum CodexEvent {
     AgentMessage {
@@ -29,6 +34,10 @@ pub enum CodexEvent {
         arguments: Value,
         #[serde(default)]
         status: Option<String>,
+        #[serde(default)]
+        output: Option<Value>,
+        #[serde(default)]
+        error: Option<String>,
     },
     ToolCalls {
         calls: Vec<ToolCallItem>,
@@ -46,13 +55,17 @@ pub enum CodexEvent {
     Unknown,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ToolCallItem {
     pub id: String,
     pub name: String,
     pub arguments: Value,
     #[serde(default)]
     pub status: Option<String>,
+    #[serde(default)]
+    pub output: Option<Value>,
+    #[serde(default)]
+    pub error: Option<String>,
 }
 
 /// ACP session update event for streaming
@@ -142,6 +155,8 @@ pub struct CodexStreamManager {
     tx: mpsc::UnboundedSender<SessionUpdate>,
     last_sent_chunk: Option<String>,
     finalized: bool,
+    /// Track tool calls that have been sent to avoid duplicate pending events
+    tool_call_states: HashMap<String, ToolCallStatus>,
 }
 
 impl CodexStreamManager {
@@ -151,6 +166,7 @@ impl CodexStreamManager {
             tx,
             last_sent_chunk: None,
             finalized: false,
+            tool_call_states: HashMap::new(),
         }
     }
 
@@ -193,14 +209,23 @@ impl CodexStreamManager {
                 name,
                 arguments,
                 status,
+                output,
+                error,
             } => {
-                self.send_tool_call(id, name, arguments, status.as_deref())
+                self.send_tool_call(id, name, arguments, status.as_deref(), output, error)
                     .await?;
             }
             CodexEvent::ToolCalls { calls } => {
                 for call in calls {
-                    self.send_tool_call(call.id, call.name, call.arguments, call.status.as_deref())
-                        .await?;
+                    self.send_tool_call(
+                        call.id,
+                        call.name,
+                        call.arguments,
+                        call.status.as_deref(),
+                        call.output,
+                        call.error,
+                    )
+                    .await?;
                 }
             }
             CodexEvent::TaskComplete { reason } => {
@@ -209,14 +234,85 @@ impl CodexStreamManager {
             }
             CodexEvent::Error { message, code } => {
                 error!("Codex error: {} (code: {:?})", message, code);
-                // Send error as a message chunk
-                // TODO: When in context of a tool call, send as ToolCallUpdate with status=failed
-                let error_msg = if let Some(ref code) = code {
-                    format!("Error [{}]: {}", code, message)
-                } else {
-                    format!("Error: {}", message)
+
+                // Map Codex error codes to semantic categories
+                let error_category = match code.as_deref() {
+                    Some("timeout") | Some("TIMEOUT") => "timeout",
+                    Some("permission_denied") | Some("PERMISSION_DENIED") => "permission_denied",
+                    Some("not_found") | Some("NOT_FOUND") => "not_found",
+                    Some("cancelled") | Some("CANCELLED") => "cancelled",
+                    Some("rate_limit") | Some("RATE_LIMIT") => "rate_limit",
+                    _ => "error",
                 };
-                self.send_chunk(error_msg).await?;
+
+                // Check if this error is in the context of a tool call
+                // If we have active tool calls, map the error to the most recent one
+                if let Some((tool_id, _)) = self.tool_call_states.iter().last() {
+                    // Send as ToolCallUpdate with status=failed for the last tool
+                    let tool_id_str = tool_id.clone();
+
+                    // Format error message with category
+                    let error_text = match error_category {
+                        "timeout" => format!("Tool execution timed out: {}", message),
+                        "permission_denied" => format!("Permission denied: {}", message),
+                        "not_found" => format!("Resource not found: {}", message),
+                        "cancelled" => format!("Tool execution cancelled: {}", message),
+                        "rate_limit" => format!("Rate limit exceeded: {}", message),
+                        _ => {
+                            if let Some(ref code) = code {
+                                format!("Error [{}]: {}", code, message)
+                            } else {
+                                format!("Error: {}", message)
+                            }
+                        }
+                    };
+
+                    let update = SessionUpdate {
+                        jsonrpc: "2.0".to_string(),
+                        method: "session/update".to_string(),
+                        params: SessionUpdateParams {
+                            session_id: self.session_id.clone(),
+                            update: SessionUpdateContent::ToolCallUpdate {
+                                tool_call_id: tool_id_str.clone(),
+                                title: None,
+                                kind: None,
+                                status: Some(ToolCallStatus::Failed),
+                                content: Some(vec![ContentBlock::Text { text: error_text }]),
+                                locations: None,
+                                raw_input: None,
+                                raw_output: Some(json!({
+                                    "error": message,
+                                    "code": code,
+                                    "category": error_category
+                                })),
+                            },
+                        },
+                    };
+                    self.tx
+                        .send(update)
+                        .context("Failed to send error update")?;
+
+                    // Mark the tool as failed in our tracking
+                    self.tool_call_states
+                        .insert(tool_id_str, ToolCallStatus::Failed);
+                } else {
+                    // No tool context, send as a message chunk
+                    let error_msg = match error_category {
+                        "timeout" => format!("Operation timed out: {}", message),
+                        "permission_denied" => format!("Permission denied: {}", message),
+                        "not_found" => format!("Not found: {}", message),
+                        "cancelled" => format!("Operation cancelled: {}", message),
+                        "rate_limit" => format!("Rate limit exceeded: {}", message),
+                        _ => {
+                            if let Some(ref code) = code {
+                                format!("Error [{}]: {}", code, message)
+                            } else {
+                                format!("Error: {}", message)
+                            }
+                        }
+                    };
+                    self.send_chunk(error_msg).await?;
+                }
             }
             CodexEvent::Unknown => {
                 debug!("Unknown Codex event type");
@@ -259,42 +355,171 @@ impl CodexStreamManager {
         Ok(())
     }
 
-    /// Send a tool call event
+    /// Send a tool call event with enhanced status tracking and output formatting
     async fn send_tool_call(
         &mut self,
         id: String,
         name: String,
         arguments: Value,
         status: Option<&str>,
+        output: Option<Value>,
+        error: Option<String>,
     ) -> Result<()> {
+        // Parse the status
         let tool_status = match status.unwrap_or("pending") {
-            "completed" => ToolCallStatus::Completed,
-            "in_progress" => ToolCallStatus::InProgress,
-            "failed" => ToolCallStatus::Failed,
+            "completed" | "success" => ToolCallStatus::Completed,
+            "in_progress" | "running" => ToolCallStatus::InProgress,
+            "failed" | "error" => ToolCallStatus::Failed,
             _ => ToolCallStatus::Pending,
         };
 
-        // For tool calls, use the name as the title
-        let title = name.clone();
+        // Check if we've already sent this tool call to track state transitions
+        let previous_status = self.tool_call_states.get(&id).copied();
 
-        // Determine tool kind based on the name (this is a heuristic)
-        let kind = if name.contains("read") || name.contains("get") {
-            Some("read".to_string())
-        } else if name.contains("write") || name.contains("edit") || name.contains("update") {
-            Some("edit".to_string())
-        } else if name.contains("delete") || name.contains("remove") {
-            Some("delete".to_string())
-        } else if name.contains("search") || name.contains("find") {
-            Some("search".to_string())
-        } else if name.contains("exec") || name.contains("run") || name.contains("shell") {
-            Some("execute".to_string())
+        // Determine if this is an initial call or an update
+        let is_initial = previous_status.is_none();
+
+        // Update our tracking
+        self.tool_call_states.insert(id.clone(), tool_status);
+
+        // Extract shell parameters if this is a shell tool
+        let shell_params =
+            if name.contains("shell") || name.contains("bash") || name.contains("command") {
+                Some(extract_shell_params(&name, &arguments))
+            } else {
+                None
+            };
+
+        // Determine the title - for shell commands, include workdir if different
+        let title = if let Some(cmd) = extract_shell_command(&name, &arguments) {
+            if let Some(ref params) = shell_params {
+                if let Some(ref workdir) = params.workdir {
+                    format!("{}: {} (in {})", name, cmd, workdir)
+                } else {
+                    format!("{}: {}", name, cmd)
+                }
+            } else {
+                format!("{}: {}", name, cmd)
+            }
         } else {
-            Some("other".to_string())
+            name.clone()
         };
 
-        // Use ToolCall for initial call, ToolCallUpdate for status changes
-        let update = if tool_status == ToolCallStatus::Pending {
-            // Initial tool call
+        // Map to ACP tool kind using our utility
+        let kind = Some(map_tool_kind(&name));
+
+        // Build locations array if workdir is present
+        let locations = if let Some(ref params) = shell_params {
+            params.workdir.as_ref().map(|dir| {
+                vec![json!({
+                    "path": dir,
+                    "type": "directory"
+                })]
+            })
+        } else {
+            None
+        };
+
+        // Format content based on output/error
+        let content =
+            if tool_status == ToolCallStatus::Completed || tool_status == ToolCallStatus::Failed {
+                let mut content_blocks = Vec::new();
+
+                // Add output if present
+                if let Some(ref out) = output {
+                    let formatted = format_tool_output(&name, out, MAX_OUTPUT_PREVIEW_BYTES);
+                    if !formatted.is_empty() {
+                        content_blocks.push(ContentBlock::Text { text: formatted });
+                    }
+                }
+
+                // Add error if present
+                if let Some(ref err) = error {
+                    content_blocks.push(ContentBlock::Text {
+                        text: format!("[Error]: {}", err),
+                    });
+                }
+
+                // Default message if no output or error
+                if content_blocks.is_empty() {
+                    content_blocks.push(ContentBlock::Text {
+                        text: match tool_status {
+                            ToolCallStatus::Completed => {
+                                "Tool execution completed successfully".to_string()
+                            }
+                            ToolCallStatus::Failed => "Tool execution failed".to_string(),
+                            _ => format!("Tool status: {:?}", tool_status),
+                        },
+                    });
+                }
+
+                Some(content_blocks)
+            } else if tool_status == ToolCallStatus::InProgress {
+                Some(vec![ContentBlock::Text {
+                    text: "Tool is running...".to_string(),
+                }])
+            } else {
+                None
+            };
+
+        // Enhance raw_input with extracted parameters for debugging
+        let enhanced_raw_input = if let Some(ref params) = shell_params {
+            let mut enhanced = json!({
+                "original": arguments,
+                "extracted": {}
+            });
+
+            if let Some(obj) = enhanced["extracted"].as_object_mut() {
+                if let Some(ref cmd) = params.command {
+                    obj.insert("command".to_string(), json!(cmd));
+                }
+                if let Some(ref workdir) = params.workdir {
+                    obj.insert("workdir".to_string(), json!(workdir));
+                }
+                if let Some(timeout) = params.timeout_ms {
+                    obj.insert("timeout_ms".to_string(), json!(timeout));
+                }
+                if let Some(escalated) = params.with_escalated_permissions {
+                    obj.insert("with_escalated_permissions".to_string(), json!(escalated));
+                }
+                if let Some(ref justification) = params.justification {
+                    obj.insert("justification".to_string(), json!(justification));
+                }
+            }
+
+            enhanced
+        } else {
+            arguments.clone()
+        };
+
+        // Prepare raw output for completed/failed states
+        let raw_output = if tool_status == ToolCallStatus::Completed
+            || tool_status == ToolCallStatus::Failed
+        {
+            if let Some(ref err) = error {
+                Some(json!({
+                    "status": "failed",
+                    "error": err
+                }))
+            } else if let Some(ref out) = output {
+                // Include full output in raw_output
+                Some(out.clone())
+            } else {
+                Some(json!({
+                    "status": if tool_status == ToolCallStatus::Completed { "completed" } else { "failed" }
+                }))
+            }
+        } else {
+            None
+        };
+
+        // Create the appropriate update based on whether this is initial or update
+        let update = if is_initial {
+            // Initial tool call - send as ToolCall
+            debug!(
+                "Sending initial tool call {} with status {:?}",
+                id, tool_status
+            );
             SessionUpdate {
                 jsonrpc: "2.0".to_string(),
                 method: "session/update".to_string(),
@@ -302,18 +527,29 @@ impl CodexStreamManager {
                     session_id: self.session_id.clone(),
                     update: SessionUpdateContent::ToolCall {
                         tool_call_id: id,
-                        title,
-                        kind,
+                        title: title.clone(),
+                        kind: kind.clone(),
                         status: Some(tool_status),
-                        content: None,
-                        locations: None,
-                        raw_input: Some(arguments),
-                        raw_output: None,
+                        content: content.clone(),
+                        locations,
+                        raw_input: Some(enhanced_raw_input.clone()),
+                        raw_output: raw_output.clone(),
                     },
                 },
             }
         } else {
-            // Tool call update (status change)
+            // Status update - send as ToolCallUpdate
+            debug!(
+                "Sending tool call update for {} from {:?} to {:?}",
+                id, previous_status, tool_status
+            );
+
+            // Only send update if status actually changed or we have new output
+            if previous_status == Some(tool_status) && output.is_none() && error.is_none() {
+                trace!("Skipping duplicate status update for tool {}", id);
+                return Ok(());
+            }
+
             SessionUpdate {
                 jsonrpc: "2.0".to_string(),
                 method: "session/update".to_string(),
@@ -324,24 +560,10 @@ impl CodexStreamManager {
                         title: None, // Don't repeat title in updates
                         kind: None,  // Don't repeat kind in updates
                         status: Some(tool_status),
-                        content: if tool_status == ToolCallStatus::Completed {
-                            // Include a preview of output when completed
-                            Some(vec![ContentBlock::Text {
-                                text: "Tool execution completed".to_string(),
-                            }])
-                        } else {
-                            None
-                        },
+                        content,
                         locations: None,
                         raw_input: None, // Already sent in initial call
-                        raw_output: if tool_status == ToolCallStatus::Completed
-                            || tool_status == ToolCallStatus::Failed
-                        {
-                            // TODO: Capture actual output from tool
-                            Some(json!({"status": tool_status}))
-                        } else {
-                            None
-                        },
+                        raw_output,
                     },
                 },
             }

--- a/crates/codex-cli-acp/src/lib.rs
+++ b/crates/codex-cli-acp/src/lib.rs
@@ -1,4 +1,5 @@
 //! Library interface for codex-cli-acp
 
 pub mod codex_proto;
+pub mod tool_calls;
 pub mod validation;

--- a/crates/codex-cli-acp/src/main.rs
+++ b/crates/codex-cli-acp/src/main.rs
@@ -37,6 +37,7 @@ impl Default for ServerConfig {
 }
 
 mod codex_proto;
+mod tool_calls;
 mod validation;
 
 struct SessionState {

--- a/crates/codex-cli-acp/src/tool_calls.rs
+++ b/crates/codex-cli-acp/src/tool_calls.rs
@@ -1,0 +1,568 @@
+//! Tool call utilities for mapping Codex events to ACP protocol
+//!
+//! This module provides utilities for:
+//! - Mapping tool names to ACP ToolKind categories
+//! - Truncating tool output for preview (2KB limit)
+//! - Formatting tool calls for ACP protocol compliance
+
+use serde_json::Value;
+use tracing::debug;
+
+/// Maximum size for tool output preview in bytes (2KB)
+pub const MAX_OUTPUT_PREVIEW_BYTES: usize = 2048;
+
+/// Extracted shell tool parameters matching Codex's ShellToolCallParams
+#[derive(Debug, Clone, Default)]
+pub struct ExtractedShellParams {
+    pub command: Option<String>,
+    pub workdir: Option<String>,
+    pub timeout_ms: Option<u64>,
+    pub with_escalated_permissions: Option<bool>,
+    pub justification: Option<String>,
+}
+
+/// Map a tool name to an ACP ToolKind category
+///
+/// This function categorizes tools based on their names to help clients
+/// choose appropriate icons and UI treatment.
+pub fn map_tool_kind(tool_name: &str) -> String {
+    let name_lower = tool_name.to_lowercase();
+
+    // Check for fetch operations first (network tools often have specific prefixes)
+    if (name_lower.contains("fetch") && !name_lower.contains("fetch_file"))
+        || name_lower.contains("download")
+        || name_lower.contains("curl")
+        || name_lower.contains("wget")
+        || name_lower.contains("http")
+    {
+        return "fetch".to_string();
+    }
+
+    // Check for search operations (before read, as some search tools contain "get")
+    if name_lower.contains("search")
+        || name_lower.contains("find")
+        || name_lower.contains("grep")
+        || name_lower.contains("locate")
+        || name_lower.contains("query")
+    {
+        return "search".to_string();
+    }
+
+    // Check for read operations
+    if name_lower.contains("read")
+        || name_lower.contains("get")
+        || name_lower.contains("fetch_file")
+        || name_lower.contains("view")
+        || name_lower.contains("cat")
+        || name_lower.contains("list")
+    {
+        return "read".to_string();
+    }
+
+    // Check for edit operations
+    if name_lower.contains("write")
+        || name_lower.contains("edit")
+        || name_lower.contains("update")
+        || name_lower.contains("modify")
+        || name_lower.contains("patch")
+        || name_lower.contains("change")
+        || name_lower.contains("set")
+    {
+        return "edit".to_string();
+    }
+
+    // Check for delete operations
+    if name_lower.contains("delete")
+        || name_lower.contains("remove")
+        || name_lower.starts_with("rm")
+    {
+        return "delete".to_string();
+    }
+
+    // Check for move operations
+    if name_lower.contains("move") || name_lower.contains("rename") || name_lower.starts_with("mv")
+    {
+        return "move".to_string();
+    }
+
+    // Check for execute operations
+    if name_lower.contains("exec")
+        || name_lower.contains("run")
+        || name_lower.contains("shell")
+        || name_lower.contains("cmd")
+        || name_lower.contains("command")
+        || name_lower.contains("execute")
+        || name_lower.contains("local_shell")
+        || name_lower.contains("bash")
+        || name_lower.contains("python")
+    {
+        return "execute".to_string();
+    }
+
+    // Check for think operations
+    if name_lower.contains("think")
+        || name_lower.contains("reason")
+        || name_lower.contains("plan")
+        || name_lower.contains("analyze")
+        || name_lower.contains("consider")
+    {
+        return "think".to_string();
+    }
+
+    // Default to other
+    "other".to_string()
+}
+
+/// Truncate output to a maximum size while preserving beginning and end
+///
+/// For outputs larger than the limit, keeps the first 75% and last 25%
+/// with a truncation marker in the middle.
+pub fn truncate_output(output: &str, max_bytes: usize) -> String {
+    let output_len = output.len();
+
+    if output_len <= max_bytes {
+        return output.to_string();
+    }
+
+    // Reserve space for the truncation marker
+    let marker = "...[truncated]...";
+    let available_bytes = max_bytes.saturating_sub(marker.len());
+
+    // Keep first 75% and last 25% of available space
+    let prefix_size = (available_bytes * 3) / 4;
+    let suffix_size = available_bytes / 4;
+
+    // Find character boundaries for clean UTF-8 truncation
+    let prefix_end = find_char_boundary(output, prefix_size);
+    let suffix_start = output_len - find_char_boundary_reverse(output, suffix_size);
+
+    let truncated_bytes = output_len - prefix_end - (output_len - suffix_start);
+    let marker_with_info = format!("...[truncated {} bytes]...", truncated_bytes);
+
+    debug!(
+        "Truncating output from {} bytes to ~{} bytes (prefix: {}, suffix: {})",
+        output_len,
+        max_bytes,
+        prefix_end,
+        output_len - suffix_start
+    );
+
+    format!(
+        "{}{}{}",
+        &output[..prefix_end],
+        marker_with_info,
+        &output[suffix_start..]
+    )
+}
+
+/// Find the nearest valid UTF-8 character boundary at or before the target position
+fn find_char_boundary(s: &str, target: usize) -> usize {
+    let mut pos = target.min(s.len());
+    while pos > 0 && !s.is_char_boundary(pos) {
+        pos -= 1;
+    }
+    pos
+}
+
+/// Find the nearest valid UTF-8 character boundary from the end
+fn find_char_boundary_reverse(s: &str, target: usize) -> usize {
+    let mut pos = target.min(s.len());
+    while pos > 0 {
+        let start = s.len() - pos;
+        if s.is_char_boundary(start) {
+            break;
+        }
+        pos -= 1;
+    }
+    pos
+}
+
+/// Extract the command from tool arguments for shell executions
+///
+/// For local_shell or similar tools, extracts the command to use as title.
+/// Supports both string and Vec<String> command formats per Codex ShellToolCallParams.
+pub fn extract_shell_command(tool_name: &str, arguments: &Value) -> Option<String> {
+    let name_lower = tool_name.to_lowercase();
+
+    if name_lower.contains("shell")
+        || name_lower.contains("exec")
+        || name_lower.contains("run")
+        || name_lower.contains("cmd")
+        || name_lower.contains("bash")
+    {
+        // Try common argument patterns
+        // First check for 'command' field (can be string or array)
+        if let Some(cmd_value) = arguments.get("command") {
+            if let Some(cmd_str) = cmd_value.as_str() {
+                return Some(cmd_str.to_string());
+            } else if let Some(cmd_array) = cmd_value.as_array() {
+                // Handle Vec<String> command format from Codex
+                let cmd_parts: Vec<String> = cmd_array
+                    .iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect();
+                if !cmd_parts.is_empty() {
+                    return Some(cmd_parts.join(" "));
+                }
+            }
+        }
+
+        // Try other common field names (usually strings)
+        if let Some(cmd) = arguments.get("cmd").and_then(|v| v.as_str()) {
+            return Some(cmd.to_string());
+        }
+        if let Some(script) = arguments.get("script").and_then(|v| v.as_str()) {
+            return Some(script.to_string());
+        }
+        if let Some(code) = arguments.get("code").and_then(|v| v.as_str()) {
+            return Some(code.to_string());
+        }
+    }
+
+    None
+}
+
+/// Extract all shell tool parameters from arguments
+///
+/// Extracts command, workdir, timeout, and permission fields per Codex ShellToolCallParams
+pub fn extract_shell_params(tool_name: &str, arguments: &Value) -> ExtractedShellParams {
+    let name_lower = tool_name.to_lowercase();
+
+    // Only extract for shell-like tools
+    if !name_lower.contains("shell")
+        && !name_lower.contains("exec")
+        && !name_lower.contains("run")
+        && !name_lower.contains("cmd")
+        && !name_lower.contains("bash")
+    {
+        return ExtractedShellParams::default();
+    }
+
+    // Extract command (string or array)
+    let command = extract_shell_command(tool_name, arguments);
+
+    // Extract workdir (check multiple field names for compatibility)
+    let workdir = arguments
+        .get("workdir")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| {
+            arguments
+                .get("cwd")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+        .or_else(|| {
+            arguments
+                .get("working_directory")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        });
+
+    // Extract timeout_ms (also check "timeout" alias)
+    let timeout_ms = arguments
+        .get("timeout_ms")
+        .and_then(|v| v.as_u64())
+        .or_else(|| arguments.get("timeout").and_then(|v| v.as_u64()));
+
+    // Extract escalated permissions flag
+    let with_escalated_permissions = arguments
+        .get("with_escalated_permissions")
+        .and_then(|v| v.as_bool())
+        .or_else(|| arguments.get("sudo").and_then(|v| v.as_bool()));
+
+    // Extract justification for escalated permissions
+    let justification = arguments
+        .get("justification")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| {
+            arguments
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        });
+
+    ExtractedShellParams {
+        command,
+        workdir,
+        timeout_ms,
+        with_escalated_permissions,
+        justification,
+    }
+}
+
+/// Format tool output for display in content blocks
+///
+/// Handles special formatting for different tool types
+pub fn format_tool_output(_tool_name: &str, output: &Value, max_preview_bytes: usize) -> String {
+    // Handle string output
+    if let Some(text) = output.as_str() {
+        return truncate_output(text, max_preview_bytes);
+    }
+
+    // Handle structured output with common fields
+    if let Some(stdout) = output.get("stdout").and_then(|v| v.as_str()) {
+        let mut result = truncate_output(stdout, max_preview_bytes);
+
+        // Add stderr if present and there's room
+        if let Some(stderr) = output.get("stderr").and_then(|v| v.as_str()) {
+            if !stderr.is_empty() {
+                let remaining = max_preview_bytes.saturating_sub(result.len());
+                if remaining > 100 {
+                    result.push_str("\n[stderr]:\n");
+                    result.push_str(&truncate_output(stderr, remaining - 12));
+                }
+            }
+        }
+
+        // Add exit code if present
+        if let Some(code) = output.get("exit_code").and_then(|v| v.as_i64()) {
+            if code != 0 {
+                result.push_str(&format!("\n[exit code: {}]", code));
+            }
+        }
+
+        return result;
+    }
+
+    // Handle array output (e.g., list of items)
+    if let Some(array) = output.as_array() {
+        let items: Vec<String> = array
+            .iter()
+            .take(10)
+            .map(|v| {
+                if let Some(s) = v.as_str() {
+                    s.to_string()
+                } else {
+                    format!("{}", v)
+                }
+            })
+            .collect();
+
+        let mut result = items.join("\n");
+        if array.len() > 10 {
+            result.push_str(&format!("\n... and {} more items", array.len() - 10));
+        }
+
+        return truncate_output(&result, max_preview_bytes);
+    }
+
+    // Fallback to JSON representation
+    let json_str = serde_json::to_string_pretty(output).unwrap_or_else(|_| output.to_string());
+
+    truncate_output(&json_str, max_preview_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_map_tool_kind() {
+        // Read operations
+        assert_eq!(map_tool_kind("read_file"), "read");
+        assert_eq!(map_tool_kind("get_content"), "read");
+        assert_eq!(map_tool_kind("fetch_file_data"), "read");
+        assert_eq!(map_tool_kind("view_document"), "read");
+        assert_eq!(map_tool_kind("cat"), "read");
+        assert_eq!(map_tool_kind("list_files"), "read");
+
+        // Edit operations
+        assert_eq!(map_tool_kind("write_file"), "edit");
+        assert_eq!(map_tool_kind("edit_content"), "edit");
+        assert_eq!(map_tool_kind("update_config"), "edit");
+        assert_eq!(map_tool_kind("modify_data"), "edit");
+        assert_eq!(map_tool_kind("patch_file"), "edit");
+
+        // Delete operations
+        assert_eq!(map_tool_kind("delete_file"), "delete");
+        assert_eq!(map_tool_kind("remove_item"), "delete");
+        assert_eq!(map_tool_kind("rm"), "delete");
+
+        // Move operations
+        assert_eq!(map_tool_kind("move_file"), "move");
+        assert_eq!(map_tool_kind("rename_document"), "move");
+        assert_eq!(map_tool_kind("mv"), "move");
+
+        // Search operations
+        assert_eq!(map_tool_kind("search_content"), "search");
+        assert_eq!(map_tool_kind("find_files"), "search");
+        assert_eq!(map_tool_kind("grep_pattern"), "search");
+
+        // Execute operations
+        assert_eq!(map_tool_kind("execute_command"), "execute");
+        assert_eq!(map_tool_kind("run_script"), "execute");
+        assert_eq!(map_tool_kind("local_shell"), "execute");
+        assert_eq!(map_tool_kind("bash_command"), "execute");
+
+        // Think operations
+        assert_eq!(map_tool_kind("think_about"), "think");
+        assert_eq!(map_tool_kind("reason_through"), "think");
+        assert_eq!(map_tool_kind("plan_approach"), "think");
+
+        // Fetch operations
+        assert_eq!(map_tool_kind("fetch_url"), "fetch");
+        assert_eq!(map_tool_kind("download_resource"), "fetch");
+        assert_eq!(map_tool_kind("curl_request"), "fetch");
+
+        // Other operations
+        assert_eq!(map_tool_kind("unknown_tool"), "other");
+        assert_eq!(map_tool_kind("custom_operation"), "other");
+    }
+
+    #[test]
+    fn test_truncate_output() {
+        // Small output - no truncation
+        let small = "Hello, world!";
+        assert_eq!(truncate_output(small, 100), small);
+
+        // Large output - truncation needed
+        let large = "a".repeat(1000);
+        let truncated = truncate_output(&large, 100);
+        assert!(truncated.len() <= 120); // Some allowance for truncation marker
+        assert!(truncated.contains("[truncated"));
+        assert!(truncated.starts_with("aaa"));
+        assert!(truncated.ends_with("aaa"));
+
+        // UTF-8 handling
+        let utf8 = "Hello 世界 ".repeat(50);
+        let truncated_utf8 = truncate_output(&utf8, 100);
+        assert!(truncated_utf8.len() <= 120);
+        assert!(truncated_utf8.contains("[truncated"));
+    }
+
+    #[test]
+    fn test_extract_shell_command() {
+        // Test string command
+        let args1 = json!({"command": "ls -la"});
+        assert_eq!(
+            extract_shell_command("local_shell", &args1),
+            Some("ls -la".to_string())
+        );
+
+        // Test Vec<String> command (Codex ShellToolCallParams format)
+        let args_vec = json!({"command": ["ls", "-la", "/tmp"]});
+        assert_eq!(
+            extract_shell_command("local_shell", &args_vec),
+            Some("ls -la /tmp".to_string())
+        );
+
+        // Test empty Vec<String> command
+        let args_empty_vec = json!({"command": []});
+        assert_eq!(extract_shell_command("shell", &args_empty_vec), None);
+
+        // Test Vec with non-string elements (should filter them out)
+        let args_mixed = json!({"command": ["echo", 123, "hello", null, "world"]});
+        assert_eq!(
+            extract_shell_command("bash", &args_mixed),
+            Some("echo hello world".to_string())
+        );
+
+        // Test other field names
+        let args2 = json!({"cmd": "pwd"});
+        assert_eq!(
+            extract_shell_command("exec", &args2),
+            Some("pwd".to_string())
+        );
+
+        let args3 = json!({"script": "echo hello"});
+        assert_eq!(
+            extract_shell_command("run_bash", &args3),
+            Some("echo hello".to_string())
+        );
+
+        // Test non-shell tool
+        let args4 = json!({"command": "value"});
+        assert_eq!(extract_shell_command("read_file", &args4), None);
+
+        // Test missing command field
+        let args5 = json!({"other": "value"});
+        assert_eq!(extract_shell_command("shell", &args5), None);
+    }
+
+    #[test]
+    fn test_extract_shell_params() {
+        // Test comprehensive parameter extraction
+        let args_full = json!({
+            "command": ["npm", "test"],
+            "workdir": "/project",
+            "timeout_ms": 30000,
+            "with_escalated_permissions": true,
+            "justification": "Need to install global packages"
+        });
+
+        let params = extract_shell_params("local_shell", &args_full);
+        assert_eq!(params.command, Some("npm test".to_string()));
+        assert_eq!(params.workdir, Some("/project".to_string()));
+        assert_eq!(params.timeout_ms, Some(30000));
+        assert_eq!(params.with_escalated_permissions, Some(true));
+        assert_eq!(
+            params.justification,
+            Some("Need to install global packages".to_string())
+        );
+
+        // Test alternative field names
+        let args_alt = json!({
+            "command": "ls -la",
+            "cwd": "/tmp",
+            "timeout": 5000,
+            "sudo": false,
+            "reason": "List files"
+        });
+
+        let params_alt = extract_shell_params("bash", &args_alt);
+        assert_eq!(params_alt.command, Some("ls -la".to_string()));
+        assert_eq!(params_alt.workdir, Some("/tmp".to_string()));
+        assert_eq!(params_alt.timeout_ms, Some(5000));
+        assert_eq!(params_alt.with_escalated_permissions, Some(false));
+        assert_eq!(params_alt.justification, Some("List files".to_string()));
+
+        // Test non-shell tool returns defaults
+        let args_other = json!({
+            "command": "test",
+            "workdir": "/project"
+        });
+
+        let params_none = extract_shell_params("read_file", &args_other);
+        assert_eq!(params_none.command, None);
+        assert_eq!(params_none.workdir, None);
+    }
+
+    #[test]
+    fn test_format_tool_output() {
+        // String output
+        let string_output = json!("Simple text output");
+        assert_eq!(
+            format_tool_output("any_tool", &string_output, 100),
+            "Simple text output"
+        );
+
+        // Structured output with stdout
+        let structured = json!({
+            "stdout": "Command output here",
+            "stderr": "Warning message",
+            "exit_code": 1
+        });
+        let formatted = format_tool_output("shell", &structured, 200);
+        assert!(formatted.contains("Command output here"));
+        assert!(formatted.contains("[stderr]"));
+        assert!(formatted.contains("Warning message"));
+        assert!(formatted.contains("[exit code: 1]"));
+
+        // Array output
+        let array = json!(["item1", "item2", "item3"]);
+        let formatted_array = format_tool_output("list", &array, 100);
+        assert!(formatted_array.contains("item1"));
+        assert!(formatted_array.contains("item2"));
+        assert!(formatted_array.contains("item3"));
+
+        // Large array - truncated
+        let large_array: Vec<String> = (0..20).map(|i| format!("item{}", i)).collect();
+        let large_json = json!(large_array);
+        let formatted_large = format_tool_output("list", &large_json, 200);
+        assert!(formatted_large.contains("item0"));
+        assert!(formatted_large.contains("... and 10 more items"));
+    }
+}

--- a/crates/codex-cli-acp/tests/tool_calls_test.rs
+++ b/crates/codex-cli-acp/tests/tool_calls_test.rs
@@ -1,0 +1,424 @@
+//! Integration tests for tool call functionality
+
+use codex_cli_acp::codex_proto::{
+    CodexEvent, CodexStreamManager, SessionUpdate, SessionUpdateContent, ToolCallItem,
+    ToolCallStatus,
+};
+use codex_cli_acp::tool_calls::{
+    extract_shell_command, format_tool_output, map_tool_kind, MAX_OUTPUT_PREVIEW_BYTES,
+};
+use serde_json::json;
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn test_single_tool_call_progression() {
+    let (tx, mut rx) = mpsc::unbounded_channel::<SessionUpdate>();
+    let mut manager = CodexStreamManager::new("test_session".to_string(), tx);
+
+    // Simulate a tool call with pending status
+    let event = CodexEvent::ToolCall {
+        id: "tool_001".to_string(),
+        name: "read_file".to_string(),
+        arguments: json!({"path": "/test/file.txt"}),
+        status: Some("pending".to_string()),
+        output: None,
+        error: None,
+    };
+
+    // Process the pending event
+    let event_json = serde_json::to_string(&event).unwrap();
+    manager.process_line(&event_json).await.unwrap();
+
+    // Check we got a ToolCall with pending status
+    let update = rx.recv().await.unwrap();
+    match &update.params.update {
+        SessionUpdateContent::ToolCall {
+            tool_call_id,
+            title,
+            kind,
+            status,
+            ..
+        } => {
+            assert_eq!(tool_call_id, "tool_001");
+            assert_eq!(title, "read_file");
+            assert_eq!(kind.as_deref(), Some("read"));
+            assert_eq!(*status, Some(ToolCallStatus::Pending));
+        }
+        _ => panic!("Expected ToolCall"),
+    }
+
+    // Simulate in_progress status
+    let event = CodexEvent::ToolCall {
+        id: "tool_001".to_string(),
+        name: "read_file".to_string(),
+        arguments: json!({"path": "/test/file.txt"}),
+        status: Some("in_progress".to_string()),
+        output: None,
+        error: None,
+    };
+
+    let event_json = serde_json::to_string(&event).unwrap();
+    manager.process_line(&event_json).await.unwrap();
+
+    // Check we got a ToolCallUpdate with in_progress status
+    let update = rx.recv().await.unwrap();
+    match &update.params.update {
+        SessionUpdateContent::ToolCallUpdate {
+            tool_call_id,
+            status,
+            ..
+        } => {
+            assert_eq!(tool_call_id, "tool_001");
+            assert_eq!(*status, Some(ToolCallStatus::InProgress));
+        }
+        _ => panic!("Expected ToolCallUpdate"),
+    }
+
+    // Simulate completed status with output
+    let event = CodexEvent::ToolCall {
+        id: "tool_001".to_string(),
+        name: "read_file".to_string(),
+        arguments: json!({"path": "/test/file.txt"}),
+        status: Some("completed".to_string()),
+        output: Some(json!({"content": "File contents here"})),
+        error: None,
+    };
+
+    let event_json = serde_json::to_string(&event).unwrap();
+    manager.process_line(&event_json).await.unwrap();
+
+    // Check we got a ToolCallUpdate with completed status and output
+    let update = rx.recv().await.unwrap();
+    match &update.params.update {
+        SessionUpdateContent::ToolCallUpdate {
+            tool_call_id,
+            status,
+            content,
+            raw_output,
+            ..
+        } => {
+            assert_eq!(tool_call_id, "tool_001");
+            assert_eq!(*status, Some(ToolCallStatus::Completed));
+            assert!(content.is_some());
+            assert!(raw_output.is_some());
+        }
+        _ => panic!("Expected ToolCallUpdate"),
+    }
+}
+
+#[tokio::test]
+async fn test_batch_tool_calls() {
+    let (tx, mut rx) = mpsc::unbounded_channel::<SessionUpdate>();
+    let mut manager = CodexStreamManager::new("test_session".to_string(), tx);
+
+    // Simulate batch tool calls
+    let event = CodexEvent::ToolCalls {
+        calls: vec![
+            ToolCallItem {
+                id: "tool_001".to_string(),
+                name: "read_file".to_string(),
+                arguments: json!({"path": "/file1.txt"}),
+                status: Some("pending".to_string()),
+                output: None,
+                error: None,
+            },
+            ToolCallItem {
+                id: "tool_002".to_string(),
+                name: "write_file".to_string(),
+                arguments: json!({"path": "/file2.txt", "content": "data"}),
+                status: Some("pending".to_string()),
+                output: None,
+                error: None,
+            },
+            ToolCallItem {
+                id: "tool_003".to_string(),
+                name: "local_shell".to_string(),
+                arguments: json!({"command": "ls -la"}),
+                status: Some("pending".to_string()),
+                output: None,
+                error: None,
+            },
+        ],
+    };
+
+    let event_json = serde_json::to_string(&event).unwrap();
+    manager.process_line(&event_json).await.unwrap();
+
+    // Check we got 3 ToolCall events
+    for i in 0..3 {
+        let update = rx.recv().await.unwrap();
+        match &update.params.update {
+            SessionUpdateContent::ToolCall {
+                tool_call_id,
+                kind,
+                status,
+                ..
+            } => {
+                assert!(tool_call_id.starts_with("tool_"));
+                assert_eq!(*status, Some(ToolCallStatus::Pending));
+
+                // Check correct kind mapping
+                if i == 0 {
+                    assert_eq!(kind.as_deref(), Some("read"));
+                } else if i == 1 {
+                    assert_eq!(kind.as_deref(), Some("edit"));
+                } else {
+                    assert_eq!(kind.as_deref(), Some("execute"));
+                }
+            }
+            _ => panic!("Expected ToolCall"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_shell_command_title() {
+    let (tx, mut rx) = mpsc::unbounded_channel::<SessionUpdate>();
+    let mut manager = CodexStreamManager::new("test_session".to_string(), tx);
+
+    // Simulate a shell command tool call
+    let event = CodexEvent::ToolCall {
+        id: "tool_shell".to_string(),
+        name: "local_shell".to_string(),
+        arguments: json!({"command": "git status --porcelain"}),
+        status: Some("pending".to_string()),
+        output: None,
+        error: None,
+    };
+
+    let event_json = serde_json::to_string(&event).unwrap();
+    manager.process_line(&event_json).await.unwrap();
+
+    // Check the title includes the command
+    let update = rx.recv().await.unwrap();
+    match &update.params.update {
+        SessionUpdateContent::ToolCall { title, kind, .. } => {
+            assert!(title.contains("git status --porcelain"));
+            assert_eq!(kind.as_deref(), Some("execute"));
+        }
+        _ => panic!("Expected ToolCall"),
+    }
+}
+
+#[tokio::test]
+async fn test_tool_output_truncation() {
+    let (tx, mut rx) = mpsc::unbounded_channel::<SessionUpdate>();
+    let mut manager = CodexStreamManager::new("test_session".to_string(), tx);
+
+    // Create large output that exceeds 2KB
+    let large_output = "a".repeat(5000);
+
+    // Simulate completed tool call with large output
+    let event = CodexEvent::ToolCall {
+        id: "tool_large".to_string(),
+        name: "local_shell".to_string(),
+        arguments: json!({"command": "cat largefile.txt"}),
+        status: Some("completed".to_string()),
+        output: Some(json!({
+            "stdout": large_output.clone(),
+            "exit_code": 0
+        })),
+        error: None,
+    };
+
+    let event_json = serde_json::to_string(&event).unwrap();
+    manager.process_line(&event_json).await.unwrap();
+
+    // Check the output is truncated in content but full in raw_output
+    let update = rx.recv().await.unwrap();
+    match &update.params.update {
+        SessionUpdateContent::ToolCall {
+            content,
+            raw_output,
+            ..
+        } => {
+            // Content should be truncated
+            let content_text = &content.as_ref().unwrap()[0];
+            let codex_cli_acp::codex_proto::ContentBlock::Text { text } = content_text;
+            assert!(text.len() <= MAX_OUTPUT_PREVIEW_BYTES + 100); // Allow for truncation marker
+            assert!(text.contains("[truncated"));
+            assert!(text.starts_with("aaa"));
+            assert!(text.ends_with("[exit code: 0]") || text.contains("aaa"));
+
+            // Raw output should have full content
+            let raw = raw_output.as_ref().unwrap();
+            assert_eq!(raw["stdout"], large_output);
+        }
+        _ => panic!("Expected ToolCall"),
+    }
+}
+
+#[tokio::test]
+async fn test_tool_error_handling() {
+    let (tx, mut rx) = mpsc::unbounded_channel::<SessionUpdate>();
+    let mut manager = CodexStreamManager::new("test_session".to_string(), tx);
+
+    // Simulate failed tool call with error
+    let event = CodexEvent::ToolCall {
+        id: "tool_error".to_string(),
+        name: "write_file".to_string(),
+        arguments: json!({"path": "/readonly/file.txt", "content": "data"}),
+        status: Some("failed".to_string()),
+        output: None,
+        error: Some("Permission denied: cannot write to /readonly/file.txt".to_string()),
+    };
+
+    let event_json = serde_json::to_string(&event).unwrap();
+    manager.process_line(&event_json).await.unwrap();
+
+    // Check error is included in content
+    let update = rx.recv().await.unwrap();
+    match &update.params.update {
+        SessionUpdateContent::ToolCall {
+            status,
+            content,
+            raw_output,
+            ..
+        } => {
+            assert_eq!(*status, Some(ToolCallStatus::Failed));
+
+            // Content should include error message
+            let content_text = &content.as_ref().unwrap()[0];
+            let codex_cli_acp::codex_proto::ContentBlock::Text { text } = content_text;
+            assert!(text.contains("Permission denied"));
+
+            // Raw output should indicate failure
+            let raw = raw_output.as_ref().unwrap();
+            assert_eq!(raw["status"], "failed");
+            assert!(raw["error"].as_str().unwrap().contains("Permission denied"));
+        }
+        _ => panic!("Expected ToolCall"),
+    }
+}
+
+#[test]
+fn test_tool_kind_mapping_comprehensive() {
+    // Test all categories thoroughly
+    let test_cases = vec![
+        // Read operations
+        ("read_file", "read"),
+        ("get_content", "read"),
+        ("fetch_file_data", "read"),
+        ("cat", "read"),
+        ("list_files", "read"),
+        ("view_source", "read"),
+        // Edit operations
+        ("write_file", "edit"),
+        ("edit_config", "edit"),
+        ("update_settings", "edit"),
+        ("modify_data", "edit"),
+        ("patch_file", "edit"),
+        ("change_value", "edit"),
+        ("set_property", "edit"),
+        // Delete operations
+        ("delete_file", "delete"),
+        ("remove_item", "delete"),
+        ("rm", "delete"),
+        ("rmdir", "delete"),
+        // Move operations
+        ("move_file", "move"),
+        ("rename_folder", "move"),
+        ("mv", "move"),
+        // Search operations
+        ("search_code", "search"),
+        ("find_pattern", "search"),
+        ("grep_files", "search"),
+        ("locate_item", "search"),
+        ("query_database", "search"),
+        // Execute operations
+        ("execute_command", "execute"),
+        ("run_script", "execute"),
+        ("local_shell", "execute"),
+        ("bash", "execute"),
+        ("python_exec", "execute"),
+        ("cmd_run", "execute"),
+        // Think operations
+        ("think_about_problem", "think"),
+        ("reason_through", "think"),
+        ("plan_solution", "think"),
+        ("analyze_code", "think"),
+        ("consider_options", "think"),
+        // Fetch operations
+        ("fetch_url", "fetch"),
+        ("download_file", "fetch"),
+        ("curl_request", "fetch"),
+        ("wget_resource", "fetch"),
+        ("http_get", "fetch"),
+        // Other operations
+        ("custom_tool", "other"),
+        ("unknown_operation", "other"),
+        ("special_function", "other"),
+    ];
+
+    for (tool_name, expected_kind) in test_cases {
+        assert_eq!(
+            map_tool_kind(tool_name),
+            expected_kind,
+            "Tool '{}' should map to '{}'",
+            tool_name,
+            expected_kind
+        );
+    }
+}
+
+#[test]
+fn test_shell_command_extraction() {
+    // Test various argument patterns
+    assert_eq!(
+        extract_shell_command("local_shell", &json!({"command": "ls -la"})),
+        Some("ls -la".to_string())
+    );
+
+    assert_eq!(
+        extract_shell_command("exec", &json!({"cmd": "pwd"})),
+        Some("pwd".to_string())
+    );
+
+    assert_eq!(
+        extract_shell_command("run_bash", &json!({"script": "echo hello"})),
+        Some("echo hello".to_string())
+    );
+
+    assert_eq!(
+        extract_shell_command("python_shell", &json!({"code": "print('test')"})),
+        Some("print('test')".to_string())
+    );
+
+    // Non-shell tools should return None
+    assert_eq!(
+        extract_shell_command("read_file", &json!({"path": "/file.txt"})),
+        None
+    );
+}
+
+#[test]
+fn test_output_formatting() {
+    // Test string output
+    let output = json!("Simple output");
+    let formatted = format_tool_output("any_tool", &output, 100);
+    assert_eq!(formatted, "Simple output");
+
+    // Test structured output with stdout/stderr
+    let output = json!({
+        "stdout": "Command successful",
+        "stderr": "Warning: deprecated",
+        "exit_code": 0
+    });
+    let formatted = format_tool_output("shell", &output, 200);
+    assert!(formatted.contains("Command successful"));
+    assert!(formatted.contains("[stderr]"));
+    assert!(formatted.contains("Warning: deprecated"));
+
+    // Test array output
+    let output = json!(["item1", "item2", "item3"]);
+    let formatted = format_tool_output("list", &output, 100);
+    assert!(formatted.contains("item1\nitem2\nitem3"));
+
+    // Test truncation of large output
+    let large = "x".repeat(3000);
+    let output = json!(large);
+    let formatted = format_tool_output("tool", &output, MAX_OUTPUT_PREVIEW_BYTES);
+    assert!(formatted.len() <= MAX_OUTPUT_PREVIEW_BYTES + 100);
+    assert!(formatted.contains("[truncated"));
+}
+// formatting: ensure trailing newline

--- a/dev-docs/design/acp-lazybridge-architecture.md
+++ b/dev-docs/design/acp-lazybridge-architecture.md
@@ -2,11 +2,8 @@
 
 本文档描述 ACPLazyBridge 的整体架构、模块划分、协议映射、扩展机制与安全策略。
 
-⚠️ ACPLazyBridge 相关接口设计 & 实现时必须严格遵循 ACP 规范 & 查询 Codex CLI 参数!
-
-- (local_refs/agent-client-protocol)
-- (local_refs/codex)
-- (local_refs/zed-acp-examples)
+⚠️ ACPLazyBridge related interface design & implementation must strictly follow ACP specifications & check Codex CLI parameters!
+**ACP-DocsAndSourceCodeReference**: [ACP-DocsAndSourceCodeReference.md](ACP-DocsAndSourceCodeReference.md)
 
 ## 1. 架构总览
 

--- a/dev-docs/plan/acp-lazybridge-project-plan.md
+++ b/dev-docs/plan/acp-lazybridge-project-plan.md
@@ -2,11 +2,8 @@
 
 本文档给出里程碑、任务分解、时间安排、风险管理与验收标准。
 
-⚠️ ACPLazyBridge 相关接口设计 & 实现时必须严格遵循 ACP 规范 & 查询 Codex CLI 参数!
-
-- (local_refs/agent-client-protocol)
-- (local_refs/codex)
-- (local_refs/zed-acp-examples)
+⚠️ ACPLazyBridge related interface design & implementation must strictly follow ACP specifications & check Codex CLI parameters!
+**ACP-DocsAndSourceCodeReference**: [ACP-DocsAndSourceCodeReference.md](ACP-DocsAndSourceCodeReference.md)
 
 ## 1. 里程碑总览
 

--- a/dev-docs/plan/issues/TEMPLATE.md
+++ b/dev-docs/plan/issues/TEMPLATE.md
@@ -5,6 +5,9 @@
 ## 背景 / 需求
 - 说明要解决的问题与范围（引用 REQ/ARC/SPEC）
 
+⚠️ ACPLazyBridge related interface design & implementation must strictly follow ACP specifications & check Codex CLI parameters!
+**ACP-DocsAndSourceCodeReference**: [ACP-DocsAndSourceCodeReference.md](ACP-DocsAndSourceCodeReference.md)
+
 ## 技术方案
 - 设计与实现要点（接口/数据结构/并发/错误处理/日志）
 

--- a/dev-docs/plan/issues/acp-v1-codex-cli-alignment-and-best-practices.md
+++ b/dev-docs/plan/issues/acp-v1-codex-cli-alignment-and-best-practices.md
@@ -1,0 +1,107 @@
+# ACPLB: codex-cli-acp Alignment with ACP v1, Codex CLI, and claude-code-acp Best Practices
+
+Status: Proposed
+Owner: ACPLazyBridge
+Blocking: Gate codex-proto-1 PR merge until this issue is completed
+
+Summary
+Align codex-cli-acp with:
+- ACP v1 protocol (responses, requests, and notifications)
+- Codex CLI tool definitions and event semantics (codex-rs)
+- Best practices from claude-code-acp agent client adapter
+
+This ensures strict compatibility with ACP IDE clients (e.g., Zed), minimizes integration surprises with Codex backends, and standardizes behavior for tool calls and streaming updates.
+
+A. ACP v1 Protocol Alignment (Spec compliance)
+Recommendations
+1) initialize response
+- protocolVersion must be integer 1
+- Use agentCapabilities (not capabilities) and nest promptCapabilities inside it
+- Include authMethods (empty array if none)
+- Do not expose fs capability in the agent’s initialize response
+
+2) session/new params
+- Accept cwd (absolute path required) per ACP schema
+- Support workingDirectory as a fallback alias only; reject if both missing
+- Validate cwd is absolute; validate mcpServers is an array when present
+
+3) Notifications: session/update
+- Use a single update object with discriminator field (e.g., sessionUpdate)
+- Provide AgentMessageChunk for agent text, ToolCall for initial tool start, ToolCallUpdate for subsequent state changes
+
+4) Methods scope
+- Remove fs/* request handlers on the agent side (they are client methods in ACP)
+
+Acceptance Criteria
+- initialize response exactly matches ACP v1 (protocolVersion=1, agentCapabilities, authMethods, no fs)
+- session/new enforces cwd absolute path; validates mcpServers array; supports workingDirectory alias without defaulting to “.”
+- All session/update events conform to schema; tests cover AgentMessageChunk, ToolCall, ToolCallUpdate
+
+Evidence
+- Unit tests verifying initialize response shape
+- Tests validating session/new parameter rules
+- JSON schema checks or jq assertions for session/update event shapes
+
+B. Codex CLI Tool Definitions Consistency (codex-rs integration)
+Recommendations
+1) Shell tool params mapping
+- Support command as Vec<String> (ShellToolCallParams.command) in addition to string; when building titles, join array with spaces
+- Honor workdir when present; ensure absolute-path validations align with ACP session cwd expectations
+
+2) Output preservation
+- Maintain full rawOutput for completed/failed ToolCalls (stdout, stderr, exit_code)
+- Keep preview content to ~2KB and UTF-8 safe (prefix/suffix + marker)
+
+3) Lifecycle mapping
+- Map Codex’s begin/end events cleanly to Pending/InProgress → Completed/Failed in ACP ToolCall/ToolCallUpdate
+- Deduplicate initial events and suppress redundant updates
+
+Acceptance Criteria
+- extract_shell_command handles both string and array command inputs
+- Completed/failed ToolCalls include rawOutput; preview uses UTF-8 safe truncation
+- ToolCall lifecycle transitions verified via integration tests (including batch scenarios)
+
+Evidence
+- Integration tests for array-form commands, lifecycle, and output preservation
+- Cross-checks with codex-rs models (protocol/src/models.rs ShellToolCallParams)
+
+C. Best Practices from claude-code-acp
+Recommendations
+1) Event structure and minimal payloads
+- Use ToolCall for initial, ToolCallUpdate for status updates
+- Avoid repeating title/kind in updates unless changed
+- Keep update messages concise, only include fields that changed
+
+2) Robust streaming
+- Deduplicate identical chunks; respect finalized state to avoid trailing noise
+- Graceful error mapping to ToolCallUpdate (status=failed) when errors are known to be tool-contextual
+
+3) IDs and correlation
+- Ensure stable tool_call_id across updates; avoid duplicate pending events for same id
+
+Acceptance Criteria
+- Tests confirm no duplicate pending ToolCalls and only meaningful updates are emitted
+- Errors within a tool context surface as ToolCallUpdate with status=failed (where applicable)
+
+Evidence
+- Session update format tests (ToolCall/ToolCallUpdate field presence and minimality)
+- Logs demonstrating deduplication and correct finalization behavior
+
+Task Breakdown (Proposed naming)
+- acp-v1-init-and-session-alignment
+  - Implement initialize response normalization and session/new strict validation
+- codex-cli-shell-params-and-output-alignment
+  - Support Vec<String> commands for titles; preserve rawOutput; validate lifecycle mapping
+- claude-acp-best-practices-streaming-and-updates
+  - Enforce minimal updates, dedupe chunks, stable tool_call_id handling, error mapping improvements
+
+References
+- ACP v1 spec and Zed references (local refs)
+- Codex repos: /Users/arthur/dev-space/codex, /Users/arthur/dev-space/codex/codex-cli, /Users/arthur/dev-space/codex/codex-rs (see protocol/src/models.rs ShellToolCallParams)
+- claude-code-acp: /Users/arthur/dev-space/claude-code-acp/
+- Existing tests: crates/codex-cli-acp/tests/* and tests/session_update_format.rs
+
+Notes
+- Do not merge .worktrees/codex-proto-1 PR until this issue’s tasks are completed by Claude Code
+- After completion, consider enabling the CI JSONL replay runner (see ci-replay-acp-v1-runner.md)
+

--- a/dev-docs/plan/issues/ci-replay-acp-v1-runner.md
+++ b/dev-docs/plan/issues/ci-replay-acp-v1-runner.md
@@ -1,0 +1,58 @@
+# ISSUE: CI Replay Runner for ACP v1 Strict Tests
+
+Status: Draft (do not schedule until core features land)
+
+Summary
+- Build a deterministic JSONL replay runner for ACP v1 to run in CI.
+- Normalize protocolVersion usage to strict ACP v1 (integer 1) in all CI replay fixtures.
+- Validate agent outputs against ACP v1 schemas and behavior checks (jq and JSON Schema).
+
+Why
+- We currently have JSONL examples used for local playback and evidence, but they mix versions of initialize params (date-string vs v1 integer) and are not wired into CI.
+- A standardized CI replay ensures protocol compliance regressions are caught early and reproducibly.
+
+Scope
+- Add a small binary (or test harness) that:
+  - Reads a JSONL request script (client → agent) with ACP v1 messages
+  - Feeds it to the agent over stdio
+  - Captures all responses and notifications to JSONL logs
+  - Validates the transcript:
+    * initialize response: protocolVersion == 1, agentCapabilities shape
+    * session/new params validation errors/success
+    * session/update event shapes: AgentMessageChunk, ToolCall, ToolCallUpdate
+    * error codes and JSON-RPC 2.0 envelope correctness
+  - Emits machine-friendly summary and exits non-zero on failure
+
+Requirements
+- Fixtures:
+  - Store under dev-docs/review/_artifacts/tests-ci/*.jsonl
+  - All initialize params use { "protocolVersion": 1 }
+- Validation:
+  - JSON Schema validation for known responses and notifications
+  - jq assertions for counts and presence (e.g., number of ToolCallUpdate completed == expected)
+- GH Actions integration:
+  - New workflow job (matrix on macos-latest and ubuntu-latest):
+    * cargo build --workspace
+    * Run replay harness against each *.jsonl fixture
+    * Upload logs on failure as artifacts
+- Security:
+  - No secrets consumed; runner must not access network or filesystem beyond working dir unless mocked
+
+Acceptance Criteria
+- CI job fails if any fixture run violates ACP v1 initialize, session/new, or session/update schema or expected behaviors
+- CI job prints concise failure diff and stores the full transcript under artifacts
+- Docs: Add a short README with how to run locally via `cargo test -p codex-cli-acp -- --ignored ci:replay`
+
+Out of Scope (for this issue)
+- Adding or refactoring agent features; this is a harness and fixtures task only
+- Non-v1 protocol fixtures
+
+Open Questions
+- Where to locate schemas for validation (vendored vs generated)?
+- Single unified replay binary vs. a test-only harness behind `#[ignore]`
+
+Next Steps
+- Confirm fixture set and expected outcomes
+- Implement replay harness (Rust or minimal Node/Python if preferred), prefer Rust for easy CI integration
+- Wire GH Actions job (allow-failure initially until stabilized)
+

--- a/dev-docs/plan/issues/codex-tools-1-DONE.md
+++ b/dev-docs/plan/issues/codex-tools-1-DONE.md
@@ -1,0 +1,136 @@
+# ISSUE: codex-tools-1 — ToolCalls Standardization & 2KB Preview (COMPLETED)
+
+⚠️ ACPLazyBridge related interface design & implementation must strictly follow ACP specifications & check Codex CLI parameters!
+**ACP-DocsAndSourceCodeReference**: [ACP-DocsAndSourceCodeReference.md](ACP-DocsAndSourceCodeReference.md)
+
+## Status: ✅ COMPLETED
+
+## Branch
+- **Name**: feature/codex-tools-1
+- **Worktree**: /Users/arthur/dev-space/acplb-worktrees/codex-tools-1
+
+## Summary
+Successfully implemented comprehensive tool call support for the ACPLazyBridge Codex adapter, including:
+- Tool call event parsing and status progression (pending → in_progress → completed/failed)
+- Proper ToolKind mapping based on tool names
+- 2KB stdout preview truncation for large outputs
+- Batch tool call processing support
+- Enhanced error handling and output formatting
+
+## Implementation Details
+
+### 1. Created `tool_calls.rs` Module
+**File**: `crates/codex-cli-acp/src/tool_calls.rs`
+- `map_tool_kind()`: Maps tool names to ACP ToolKind categories (read, edit, delete, move, search, execute, think, fetch, other)
+- `truncate_output()`: Smart truncation preserving 75% beginning and 25% end with UTF-8 safety
+- `extract_shell_command()`: Extracts command from tool arguments for shell executions
+- `format_tool_output()`: Formats tool output with special handling for stdout/stderr/exit_code
+
+### 2. Enhanced `codex_proto.rs`
+**File**: `crates/codex-cli-acp/src/codex_proto.rs`
+- Extended `CodexEvent` enum to include output and error fields
+- Enhanced `CodexStreamManager` with tool call state tracking
+- Implemented comprehensive `send_tool_call()` method with:
+  - Status progression tracking (avoids duplicate events)
+  - Title formatting (uses command for shell tools)
+  - Content formatting with 2KB preview
+  - Raw output preservation for complete data
+
+### 3. Test Coverage
+- **Unit Tests**: `crates/codex-cli-acp/src/tool_calls.rs` (4 tests)
+  - Tool kind mapping
+  - Output truncation
+  - Shell command extraction
+  - Output formatting
+  
+- **Integration Tests**: `crates/codex-cli-acp/tests/tool_calls_test.rs` (8 tests)
+  - Single tool call progression
+  - Batch tool calls processing
+  - Shell command title formatting
+  - Large output truncation
+  - Error handling
+  - Comprehensive tool kind mapping
+
+- **JSONL Test Cases**: `dev-docs/review/_artifacts/tests/`
+  - `tool_calls.jsonl`: Basic tool call scenario
+  - `tool_calls_batch.jsonl`: Multiple simultaneous tool calls
+  - `tool_calls_large_output.jsonl`: 2KB truncation test
+
+## Acceptance Criteria Verification
+
+✅ **Single tool calls progress through pending → in_progress → completed states**
+- Implemented in `send_tool_call()` with state tracking via `tool_call_states` HashMap
+
+✅ **Batch tool calls are processed individually with proper status tracking**
+- `CodexEvent::ToolCalls` variant processes each call independently
+
+✅ **local_shell commands show command as title and include 2KB stdout preview**
+- `extract_shell_command()` extracts command for title
+- `format_tool_output()` truncates stdout to 2KB with preserved beginning/end
+
+✅ **Tool kinds are correctly mapped based on tool names**
+- Comprehensive mapping with proper precedence (fetch → search → read → ...)
+
+✅ **Output truncation preserves both beginning and end of content**
+- Smart truncation: 75% prefix + truncation marker + 25% suffix
+
+✅ **All tool call events conform to ACP schema specification**
+- Uses proper ToolCall/ToolCallUpdate variants per ACP protocol
+
+✅ **JSONL test cases pass validation with proper event sequences**
+- All tests passing: 37 total tests, 0 failures
+
+## Code Quality
+
+### Compilation
+- ✅ No errors
+- ✅ No warnings (fixed unused variables and imports)
+- ✅ Release build successful
+
+### Test Results
+```
+test result: ok. 37 passed; 0 failed; 0 ignored
+```
+
+## Files Modified/Created
+
+### Created
+1. `crates/codex-cli-acp/src/tool_calls.rs` - Core utilities module
+2. `crates/codex-cli-acp/tests/tool_calls_test.rs` - Integration tests
+3. `dev-docs/review/_artifacts/tests/tool_calls.jsonl` - JSONL test case
+4. `dev-docs/review/_artifacts/tests/tool_calls_batch.jsonl` - Batch test case
+5. `dev-docs/review/_artifacts/tests/tool_calls_large_output.jsonl` - Large output test
+
+### Modified
+1. `crates/codex-cli-acp/src/lib.rs` - Added tool_calls module export
+2. `crates/codex-cli-acp/src/main.rs` - Added tool_calls module import
+3. `crates/codex-cli-acp/src/codex_proto.rs` - Enhanced tool call handling
+4. `crates/codex-cli-acp/tests/session_update_format.rs` - Existing tests remain passing
+
+## Compliance with Requirements
+
+### ACP Specification Compliance
+- ✅ JSON-RPC 2.0 message format maintained
+- ✅ Tool call events follow schema.json structure
+- ✅ Proper use of ToolCall vs ToolCallUpdate
+
+### Codex CLI Integration
+- ✅ Parses Codex proto events correctly
+- ✅ Maps tool_call and tool_calls events
+- ✅ Handles status progression
+
+### Zed Reference Alignment
+- ✅ Matches Zed's ToolCall/ToolCallUpdate structure
+- ✅ Includes all required fields (title, kind, status, content, locations, raw_input, raw_output)
+- ✅ Proper status enum values (pending, in_progress, completed, failed)
+
+## Next Steps
+This implementation is complete and ready for:
+1. Integration testing with actual Codex CLI
+2. PR submission with evidence from test runs
+3. Merge to main after review
+
+## Evidence Location
+- Test outputs: Can be generated via `cargo test --package codex-cli-acp 2>&1 | tee dev-docs/review/_artifacts/logs/test_$(date +%Y%m%d_%H%M%S).log`
+- Build artifacts: `target/release/codex-cli-acp`
+- JSONL test cases: `dev-docs/review/_artifacts/tests/tool_calls*.jsonl`

--- a/dev-docs/plan/issues/feature-codex-tools-1.md
+++ b/dev-docs/plan/issues/feature-codex-tools-1.md
@@ -1,0 +1,67 @@
+# feature/codex-tools-1 — ToolCalls standardization + 2KB preview
+
+## 背景 / 需求
+- 将 Codex 的工具调用事件标准化为 ACP 规范期望的结构：
+  - initial `tool_call`（pending）；后续 `tool_call_update`（in_progress → completed/failed）
+  - 字段：toolCallId/title/kind/status/content[](ContentBlock)/locations/rawInput/rawOutput
+- 对于本地命令（local_shell 等），在 `completed` 时提供 stdout 预览（2KB 截断），便于 IDE 侧 UI 快速呈现。
+
+⚠️ ACPLazyBridge related interface design & implementation must strictly follow ACP specifications & check Codex CLI parameters!
+**ACP-DocsAndSourceCodeReference**: [ACP-DocsAndSourceCodeReference.md](ACP-DocsAndSourceCodeReference.md)
+
+参考（需求/架构/计划）
+- dev-docs/requirements/acp-lazybridge-requirements.md
+- dev-docs/design/acp-lazybridge-architecture.md
+- dev-docs/plan/acp-lazybridge-project-plan.md
+- dev-docs/plan/m1-technical-implementation-plan.md
+- dev-docs/plan/issues/m1-issue-list.md（codex-tools-1）
+
+## 技术方案
+- 在 `crates/codex-cli-acp/src/codex_proto.rs`：
+  - 定义 `ContentBlock`（已存在：Text），后续可扩展为 image/audio；
+  - 初次事件使用 `SessionUpdateContent::ToolCall`（status=pending），包含 rawInput；
+  - 后续状态采用 `SessionUpdateContent::ToolCallUpdate`（status=in_progress/completed/failed），rawOutput 在完成/失败时提供；
+  - 裁剪预览：对 `raw_output.stdout` 截断到 2048 bytes（UTF-8 安全截断）。
+- `kind` 推断：基于 name（read/get→read；write/edit/update→edit；delete/remove→delete；search/find→search；exec/run/shell→execute；默认 other）。
+- 去重：已有 `last_sent_chunk`/`finalized` 逻辑，扩展到 ToolCall 路径，避免重复 update。
+
+## local_refs 引用
+- (local_refs/agent-client-protocol) @/Users/arthur/dev-space/ACPLazyBridge/local_refs/agent-client-protocol/schema/schema.json
+- (local_refs/zed-acp-examples) @/Users/arthur/dev-space/ACPLazyBridge/local_refs/zed-acp-examples/agent_servers/src/agent_servers.rs
+- (local_refs/codex) @/Users/arthur/dev-space/ACPLazyBridge/local_refs/codex/docs
+
+## 对应的 dev-docs/review 条目
+- SPEC: SPEC-ACP-STREAM-0003（tool_call/tool_call_update）
+- REQ: REQ-LAZY-0003（工具调用标准化、预览）
+- ARC: ARC-LAZY-0001
+- ZED: ZED-REF-0002/0005/0006（工具事件与 UI 展示）
+
+## 任务拆分
+1) 数据结构与序列化
+   - `ToolCall` vs `ToolCallUpdate` 字段校对；content 使用 `Vec<ContentBlock>`
+2) 预览截断实现
+   - UTF-8 安全 2KB 截断；只在 completed/failed 时附带 rawOutput 预览
+3) kind 推断与 title 规范
+4) 去重与终态处理
+   - 防止重复 `completed`/`failed` 重放；`finalized` 写保护
+5) 测试（单测+结构校验）
+   - 补充 `tests/session_update_format.rs` 的 ToolCall/ToolCallUpdate 覆盖
+   - JSONL 演示：`_artifacts/tests/tool_calls.jsonl`
+
+## 验收标准（DoD）
+- 单测：ToolCall/ToolCallUpdate 的结构校验通过；
+- 预览：对大输出的截断逻辑单测覆盖；
+- JSONL 回放：新增 `tool_calls.jsonl`，CI 绿；
+- 文档：记录 2KB 截断策略与字段约束。
+
+## Worktree-first
+- 分支：feature/codex-tools-1
+- 初始化：git worktree add ../acplb-worktrees/codex-tools-1 feature/codex-tools-1
+- 合并：PR 方式；traceability.csv 更新
+
+## 提交说明模板
+- Commit 标题
+  - feat(codex-tools-1): standardize ToolCall events and add 2KB stdout preview
+- PR 描述要点
+  - 字段与状态迁移；2KB 截断策略；测试与 JSONL 证明；去重与终态保护
+

--- a/dev-docs/plan/issues/m1-issue-list.md
+++ b/dev-docs/plan/issues/m1-issue-list.md
@@ -4,6 +4,9 @@
 - 每个 ISSUE 按可测试的合理范围拆分，包含：需求、技术方案、local_refs 引用、对应的 review 条目（SPEC/REQ/ARC/CODEX/ZED）、验收标准、Worktree 指南。
 - 提交要求遵循 Worktree-first 规范（见下方模板与 CLAUDE.md）。
 
+⚠️ ACPLazyBridge related interface design & implementation must strictly follow ACP specifications & check Codex CLI parameters!
+**ACP-DocsAndSourceCodeReference**: [ACP-DocsAndSourceCodeReference.md](ACP-DocsAndSourceCodeReference.md)
+
 ---
 
 ## ISSUE: core-transport-1 — 行级 JSONL 传输与子进程管控

--- a/dev-docs/plan/issues/normalize-jsonl-protocol-v1.md
+++ b/dev-docs/plan/issues/normalize-jsonl-protocol-v1.md
@@ -1,0 +1,21 @@
+# ISSUE: Normalize JSONL fixtures to ACP v1 protocolVersion (1)
+
+Status: Small follow-up (to be opened on main after PR merge)
+
+Summary
+Normalize all dev-docs/review/_artifacts/tests/*.jsonl fixtures to use integer protocolVersion 1 in initialize requests. This aligns fixtures with ACP v1 and the planned CI replay runner.
+
+Scope
+- Update JSONL fixtures under dev-docs/review/_artifacts/tests/ that currently show protocolVersion as a date string (e.g., "2024-11-05").
+- Ensure requests use: { "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "protocolVersion": 1, ... } }
+- Leave any clientCapabilities references intact if present (they are part of requests).
+
+Acceptance Criteria
+- All JSONL fixtures in the tests directory use integer protocolVersion 1.
+- Local playback tests and documentation remain consistent and pass.
+- CI replay runner (when enabled) will operate on normalized fixtures without protocol mismatches.
+
+References
+- dev-docs/plan/issues/ci-replay-acp-v1-runner.md
+- dev-docs/review/_artifacts/tests/*.jsonl
+

--- a/dev-docs/plan/issues/refresh-docs-examples-protocol-v1.md
+++ b/dev-docs/plan/issues/refresh-docs-examples-protocol-v1.md
@@ -1,0 +1,18 @@
+# ISSUE: Refresh docs examples to ACP v1 protocolVersion (1)
+
+Status: Small follow-up (to be opened on main after PR merge)
+
+Summary
+Refresh user-facing documentation examples to use integer protocolVersion 1 (instead of string dates). This improves clarity and prevents confusion for ACP v1 clients.
+
+Scope
+- Update examples in WARP.md, CLAUDE.md, and any other docs where initialize/session examples include protocolVersion.
+- Ensure examples show: { "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "protocolVersion": 1 } }
+
+Acceptance Criteria
+- All referenced docs display ACP v1 examples with integer protocolVersion.
+- No extraneous semantic changes to docs outside example blocks.
+
+References
+- dev-docs/plan/issues/ci-replay-acp-v1-runner.md
+- dev-docs/review/changes/codex-tools-1-review-2025-09-04.md

--- a/dev-docs/plan/m1-technical-implementation-plan.md
+++ b/dev-docs/plan/m1-technical-implementation-plan.md
@@ -5,6 +5,10 @@
 - 不在本阶段实现 Proxy 与插件；仅完成 M1 范围内的 Streaming/ToolCalls/权限映射/错误码/约束校验与测试。
 
 规范与参考（必须对照）
+
+⚠️ ACPLazyBridge related interface design & implementation must strictly follow ACP specifications & check Codex CLI parameters!
+**ACP-DocsAndSourceCodeReference**: [ACP-DocsAndSourceCodeReference.md](ACP-DocsAndSourceCodeReference.md)
+
 - ACP 规范（local_refs/agent-client-protocol）
   - JSON-RPC 2.0、方法/通知集合、错误码（-32700/-32600/-32601/-32602/-32603）、绝对路径与 1-based 行号、JSONL 单行
   - 事件：agent_message_chunk、tool_call（pending→completed）、Plan（可选）

--- a/dev-docs/requirements/acp-lazybridge-requirements.md
+++ b/dev-docs/requirements/acp-lazybridge-requirements.md
@@ -2,11 +2,8 @@
 
 本文档定义 ACPLazyBridge 的目标、范围、用户画像与需求清单，指导后续技术设计与实施。
 
-⚠️ ACPLazyBridge 相关接口设计 & 实现时必须严格遵循 ACP 规范 & 查询 Codex CLI 参数!
-
-- (local_refs/agent-client-protocol)
-- (local_refs/codex)
-- (local_refs/zed-acp-examples)
+⚠️ ACPLazyBridge related interface design & implementation must strictly follow ACP specifications & check Codex CLI parameters!
+**ACP-DocsAndSourceCodeReference**: [ACP-DocsAndSourceCodeReference.md](ACP-DocsAndSourceCodeReference.md)
 
 ## 1. 背景与愿景
 

--- a/dev-docs/review/_artifacts/acp_v1_additional_optimizations.md
+++ b/dev-docs/review/_artifacts/acp_v1_additional_optimizations.md
@@ -1,0 +1,87 @@
+# Additional ACP v1 Optimizations
+
+## Implemented Enhancements
+
+### 1. Extended Shell Parameter Support ✅
+
+**File**: `src/tool_calls.rs`
+
+Added comprehensive support for all Codex ShellToolCallParams fields:
+- `command`: Supports both string and Vec<String> formats
+- `workdir`: Extracted with fallback support for `cwd` and `working_directory`
+- `timeout_ms`: Supports both `timeout_ms` and `timeout` aliases
+- `with_escalated_permissions`: Supports both field name and `sudo` alias
+- `justification`: Extracted with fallback to `reason`
+
+**New Struct**:
+```rust
+pub struct ExtractedShellParams {
+    pub command: Option<String>,
+    pub workdir: Option<String>,
+    pub timeout_ms: Option<u64>,
+    pub with_escalated_permissions: Option<bool>,
+    pub justification: Option<String>,
+}
+```
+
+### 2. Enhanced Error Code Mapping ✅
+
+**File**: `src/codex_proto.rs`
+
+Implemented semantic error categorization for better user feedback:
+- `timeout` / `TIMEOUT` → "Tool execution timed out"
+- `permission_denied` / `PERMISSION_DENIED` → "Permission denied"
+- `not_found` / `NOT_FOUND` → "Resource not found"
+- `cancelled` / `CANCELLED` → "Tool execution cancelled"
+- `rate_limit` / `RATE_LIMIT` → "Rate limit exceeded"
+
+Error messages are now more descriptive and include category information in `raw_output`.
+
+### 3. Improved Tool Call Handling ✅
+
+**Enhancements**:
+- Better error context preservation in tool failures
+- Semantic error messages based on error codes
+- Extended parameter extraction for shell tools
+- Support for alternative field names for compatibility
+
+## Test Coverage
+
+Added comprehensive tests for:
+- Shell parameter extraction with all fields
+- Alternative field name handling
+- Error categorization logic
+- Vec<String> command format support
+
+## Benefits
+
+1. **Full Codex Compatibility**: Complete support for ShellToolCallParams structure
+2. **Better User Experience**: Clear, semantic error messages
+3. **Flexible Integration**: Supports various field name conventions
+4. **Enhanced Debugging**: Preserves error context and categories
+5. **Future-Proof**: Ready for additional Codex tool types
+
+## API Improvements
+
+The new functions provide:
+- `extract_shell_params()`: Complete parameter extraction for shell tools
+- Enhanced error mapping with categories
+- Backward compatibility with existing field names
+- UTF-8 safe output truncation
+
+## Compliance Status
+
+✅ ACP v1 Protocol Compliance:
+- Initialize response with integer protocolVersion
+- Proper agentCapabilities structure
+- Session validation with cwd and mcpServers
+
+✅ Codex Integration:
+- Full ShellToolCallParams support
+- Error code mapping
+- Tool event lifecycle management
+
+✅ Best Practices:
+- Minimal update payloads
+- Deduplication of events
+- Stable tool_call_id tracking

--- a/dev-docs/review/_artifacts/acp_v1_alignment_summary.md
+++ b/dev-docs/review/_artifacts/acp_v1_alignment_summary.md
@@ -1,0 +1,102 @@
+# ACP v1 Alignment Implementation Summary
+
+## Completed Tasks
+
+### 1. acp-v1-init-and-session-alignment ✅
+
+**Initialize Response Compliance:**
+- `protocolVersion`: Integer value (1) instead of string
+- `agentCapabilities`: Properly named field (not "capabilities")
+- `promptCapabilities`: Nested under `agentCapabilities`
+- `authMethods`: Required field included (empty array)
+- No `fs` capability advertised (client-side only)
+
+**Session/new Validation:**
+- `cwd`: Primary parameter (absolute path required)
+- `workingDirectory`: Supported as fallback alias
+- `mcpServers`: Required array parameter with validation
+- No defaulting to "." for relative paths
+
+### 2. codex-cli-shell-params-and-output-alignment ✅
+
+**Vec<String> Command Support:**
+- Updated `extract_shell_command()` to handle both string and Vec<String> formats
+- Aligns with Codex's `ShellToolCallParams.command: Vec<String>`
+- Joins array elements with spaces for title display
+- Filters non-string elements gracefully
+
+**Output Preservation:**
+- Full output preserved in `raw_output` field for completed/failed tool calls
+- 2KB preview in content blocks (75% prefix, 25% suffix)
+- Proper handling of stdout, stderr, and exit_code
+
+### 3. claude-acp-best-practices-streaming-and-updates ✅
+
+**Event Structure:**
+- Single `update` object with `sessionUpdate` discriminator
+- `ToolCall` for initial events, `ToolCallUpdate` for status changes
+- Minimal update payloads (only changed fields)
+- No repetition of title/kind in updates
+
+**Error Handling:**
+- Errors in tool context mapped to `ToolCallUpdate` with `status: failed`
+- Errors outside tool context sent as `AgentMessageChunk`
+- Proper tracking of tool call states with HashMap
+
+**Deduplication:**
+- Skip duplicate status updates when nothing changed
+- Track tool call states to avoid duplicate pending events
+- Deduplicate identical message chunks
+
+## Test Results
+
+All tests pass successfully:
+- 6 unit tests in lib.rs
+- 10 tests in main.rs
+- 5 playback tests
+- 8 session update format tests
+- 8 tool call tests
+
+## Evidence Files
+
+### Test Artifacts
+- `/dev-docs/review/_artifacts/tests/acp_v1_alignment.jsonl` - ACP v1 compliance test
+- `/dev-docs/review/_artifacts/tests/vec_string_command.jsonl` - Vec<String> command test
+- `/dev-docs/review/_artifacts/tests/handshake.jsonl` - Basic handshake test
+
+### Implementation Files Modified
+1. `src/main.rs` - Initialize response and session/new validation
+2. `src/tool_calls.rs` - Vec<String> command support
+3. `src/codex_proto.rs` - Error mapping and deduplication improvements
+
+## Validation Output
+
+Initialize response confirms ACP v1 compliance:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": 1,
+    "agentCapabilities": {
+      "loadSession": false,
+      "promptCapabilities": {
+        "audio": false,
+        "embeddedContext": false,
+        "image": false
+      }
+    },
+    "authMethods": []
+  }
+}
+```
+
+## Acceptance Criteria Met
+
+✅ Initialize response exactly matches ACP v1 spec
+✅ Session/new enforces cwd absolute path and validates mcpServers
+✅ Tool calls support Vec<String> commands from Codex
+✅ Completed/failed tool calls include full rawOutput
+✅ Minimal update payloads with proper deduplication
+✅ Errors in tool context map to ToolCallUpdate with status=failed
+✅ All tests pass without regression

--- a/dev-docs/review/_artifacts/shell_params_integration.md
+++ b/dev-docs/review/_artifacts/shell_params_integration.md
@@ -1,0 +1,69 @@
+# Shell Parameters Integration Complete
+
+## Overview
+Successfully integrated the ExtractedShellParams functionality into the tool call processing pipeline, eliminating dead code warnings and enhancing tool call metadata.
+
+## Changes Made
+
+### 1. Enhanced Tool Call Processing (`codex_proto.rs`)
+- Now uses `extract_shell_params` to extract comprehensive shell parameters
+- Enhanced title to show workdir when different from session cwd
+- Added locations field with workdir for IDE navigation features
+- Enhanced raw_input to include both original and extracted parameters for debugging
+
+### 2. Code Quality Improvements (`tool_calls.rs`)
+- Refactored `extract_shell_params` to use idiomatic Rust patterns
+- Eliminated clippy warnings about field reassignment
+- Improved readability with chained Option methods
+
+## Features Added
+
+### Enhanced Title Display
+Shell commands now show their working directory in the title:
+- Before: `local_shell: npm test`
+- After: `local_shell: npm test (in /project)`
+
+### Location Tracking
+Tool calls now include location metadata for IDE features:
+```json
+{
+  "locations": [{
+    "path": "/project",
+    "type": "directory"
+  }]
+}
+```
+
+### Enhanced Debug Information
+The raw_input field now includes extracted parameters:
+```json
+{
+  "raw_input": {
+    "original": { "command": ["npm", "test"], "workdir": "/project" },
+    "extracted": {
+      "command": "npm test",
+      "workdir": "/project",
+      "timeout_ms": 30000,
+      "with_escalated_permissions": false
+    }
+  }
+}
+```
+
+## Test Results
+- All 39 tests passing
+- No clippy warnings
+- Code properly formatted
+
+## Benefits
+1. **No Dead Code**: ExtractedShellParams and extract_shell_params are now actively used
+2. **Better UX**: Users can see working directory context in tool titles
+3. **IDE Integration**: Location tracking enables IDE follow-along features
+4. **Enhanced Debugging**: Extracted parameters visible in raw_input for troubleshooting
+5. **Field Compatibility**: Supports multiple field name conventions (workdir/cwd/working_directory)
+
+## Compliance
+- ✅ ACP v1 protocol compliant
+- ✅ Full Codex ShellToolCallParams support
+- ✅ Semantic error mapping maintained
+- ✅ UTF-8 safe output handling preserved

--- a/dev-docs/review/_artifacts/tests/acp_v1_alignment.jsonl
+++ b/dev-docs/review/_artifacts/tests/acp_v1_alignment.jsonl
@@ -1,0 +1,3 @@
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":true,"writeTextFile":true}}}}
+{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/Users/arthur/test","mcpServers":[]}}
+{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"{{SESSION_ID}}","prompt":[{"type":"text","text":"Run ls -la command"}]}}

--- a/dev-docs/review/_artifacts/tests/tool_calls.jsonl
+++ b/dev-docs/review/_artifacts/tests/tool_calls.jsonl
@@ -1,0 +1,3 @@
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"fs":{"readTextFile":true,"writeTextFile":true}}}}
+{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/test/project","mcpServers":[],"permissionMode":"acceptEdits"}}
+{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"session_test","prompt":"Read the file /test/file.txt and then write 'Hello' to /test/output.txt"}}

--- a/dev-docs/review/_artifacts/tests/tool_calls_batch.jsonl
+++ b/dev-docs/review/_artifacts/tests/tool_calls_batch.jsonl
@@ -1,0 +1,3 @@
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"fs":{"readTextFile":true,"writeTextFile":true}}}}
+{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/test/project","mcpServers":[],"permissionMode":"bypassPermissions"}}
+{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"session_batch","prompt":"Read three files, run a shell command, and search for a pattern"}}

--- a/dev-docs/review/_artifacts/tests/tool_calls_large_output.jsonl
+++ b/dev-docs/review/_artifacts/tests/tool_calls_large_output.jsonl
@@ -1,0 +1,3 @@
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}
+{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/test/project","mcpServers":[],"permissionMode":"acceptEdits"}}
+{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"session_large","prompt":"Run a command that produces very large output"}}

--- a/dev-docs/review/_artifacts/tests/vec_string_command.jsonl
+++ b/dev-docs/review/_artifacts/tests/vec_string_command.jsonl
@@ -1,0 +1,3 @@
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}
+{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/tmp","mcpServers":[]}}
+{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"{{SESSION_ID}}","prompt":[{"type":"text","text":"Execute command array test"}]}}

--- a/dev-docs/review/changes/codex-tools-1-code-changes-2025-09-04.md
+++ b/dev-docs/review/changes/codex-tools-1-code-changes-2025-09-04.md
@@ -1,0 +1,53 @@
+# codex-tools-1: Code Review Fixes and Optimizations (Record)
+
+Date: 2025-09-04
+Worktree: /Users/arthur/dev-space/acplb-worktrees/codex-tools-1
+Branch: feature/codex-tools-1
+
+Summary
+- Applied a safe UTF-8 boundary fix to preview truncation used in ToolCall content.
+- Brought files to exact rustfmt style to ensure fmt CI passes deterministically.
+- Fixed a missing trailing newline in a test to satisfy fmt checks.
+- Verified clippy and all tests pass after changes.
+
+Changes
+1) UTF-8 boundary fix (safe truncation)
+- File: crates/codex-cli-acp/src/tool_calls.rs
+- Function: find_char_boundary_reverse(s: &str, target: usize) -> usize
+- What: Recompute the boundary index on each loop iteration and walk backwards from the end until s.is_char_boundary(start) is true; avoids splitting multi-byte code points when building suffix.
+- Why: Prevents invalid UTF-8 slices in the 2KB preview truncation path; ensures both prefix and suffix trimming respect codepoint boundaries.
+- Impact: Improves robustness of preview content for multi-byte texts; no API change.
+
+2) Formatting (rustfmt conformance)
+- Files:
+  - crates/codex-cli-acp/src/codex_proto.rs
+  - crates/codex-cli-acp/src/tool_calls.rs
+- What: Minor whitespace/line-break adjustments per rustfmt.
+- Why: Keep formatting standardized; prevents fmt check failures in CI.
+- Impact: No semantic changes.
+
+3) Test file EOF newline for fmt
+- File: crates/codex-cli-acp/tests/tool_calls_test.rs
+- What: Ensured a final newline so cargo fmt --check succeeds.
+- Impact: No semantic changes.
+
+Verification
+- cargo fmt --check: PASS
+- cargo clippy --workspace --all-targets --all-features -D warnings: PASS
+- cargo test --workspace --all-features: PASS
+  - acp-lazy-core: 19 passed
+  - codex-cli-acp unit: 6 passed
+  - codex-cli-acp main: 10 passed (includes initialize/session validations, fs method behavior, etc.)
+  - playback tests: 5 passed
+  - session_update_format tests: 8 passed
+  - tool_calls integration tests: 8 passed (lifecycle, batch, shell title, truncation, errors)
+
+Notes and follow-ups (not yet applied)
+- extract_shell_command enhancement: Also handle command as Vec<String> (from Codex ShellToolCallParams), join by space for title. Non-breaking UI improvement.
+- CI JSONL replay harness: A separate issue draft records building a strict ACP v1 replay runner and normalization of protocolVersion in fixtures (dev-docs/plan/issues/ci-replay-acp-v1-runner.md).
+
+References
+- UTF-8 fix location: crates/codex-cli-acp/src/tool_calls.rs
+- Formatter-only changes: crates/codex-cli-acp/src/codex_proto.rs, crates/codex-cli-acp/src/tool_calls.rs
+- Test newline: crates/codex-cli-acp/tests/tool_calls_test.rs
+

--- a/dev-docs/review/changes/codex-tools-1-review-2025-09-04.md
+++ b/dev-docs/review/changes/codex-tools-1-review-2025-09-04.md
@@ -1,0 +1,60 @@
+# codex-tools-1 Review Report — ACP v1 Alignment, Codex CLI Consistency, Best Practices
+
+Date: 2025-09-04
+Branch: feature/codex-tools-1 (scoped PR based on main)
+Reviewer: Agent Mode (Warp)
+
+Summary
+- Verified ACP v1 protocol compliance in initialize/session/update.
+- Confirmed Codex CLI tool definitions mapping (ShellToolCallParams) and lifecycle alignment.
+- Compared against claude-code-acp best practices; validated minimal updates, dedupe, and error mapping.
+- Quality gates: rustfmt OK, clippy OK, tests OK across workspace.
+
+Highlights
+- Initialize response
+  - protocolVersion: 1 (integer)
+  - agentCapabilities with nested promptCapabilities
+  - authMethods included (empty)
+  - No fs capability advertised in response
+- Session/new validation
+  - Requires cwd (absolute path), workingDirectory supported as fallback
+  - mcpServers required and must be array
+- Session/update
+  - Single update object (sessionUpdate) per notification
+  - ToolCall (initial) and ToolCallUpdate (subsequent) used appropriately
+  - Minimal updates: omit title/kind on updates; dedupe identical status without new output
+- Codex CLI consistency
+  - extract_shell_command supports string and Vec<String> command with joining
+  - extract_shell_params with workdir/cwd/working_directory, timeout_ms/timeout, with_escalated_permissions/sudo, justification/reason
+  - raw_output preserves full result; content uses ~2KB UTF-8-safe preview
+- Error mapping
+  - Codex error codes mapped to semantic categories and surfaced as ToolCallUpdate (failed) when in tool context; otherwise as message chunk
+
+Quality verification
+- cargo fmt --check: PASS
+- cargo clippy --workspace --all-targets --all-features -D warnings: PASS
+- cargo test --workspace --all-features: PASS
+  - acp-lazy-core: 19 passed
+  - codex-cli-acp unit: 7 passed
+  - codex-cli-acp main: 11 passed
+  - playback: 5 passed
+  - session_update_format: 8 passed
+  - tool_calls integration: 8 passed
+
+Scope for merge (to main)
+- Include only:
+  - crates/codex-cli-acp/**
+  - dev-docs/** (issues, reviews, alignment records)
+- Exclude unrelated files outside this scope (e.g., .claude symlink, AGENTS.md removal, top-level config unrelated to this task)
+
+Follow-ups (separate issues on main after merge)
+1) Normalize JSONL fixtures to use protocolVersion: 1 across dev-docs/review/_artifacts/tests/*.jsonl to align with ACP v1 and CI replay runner.
+2) Refresh user-facing docs examples (e.g., WARP.md, CLAUDE.md) to show protocolVersion as integer 1 for clarity.
+
+References
+- codex-cli-acp/src/main.rs — initialize/session handlers and tests
+- codex-cli-acp/src/codex_proto.rs — ToolCall/ToolCallUpdate mapping, error mapping, streaming
+- codex-cli-acp/src/tool_calls.rs — UTF-8 preview truncation, ExtractedShellParams
+- dev-docs/plan/issues/acp-v1-codex-cli-alignment-and-best-practices.md — acceptance criteria
+- dev-docs/plan/issues/ci-replay-acp-v1-runner.md — future CI replay normalization
+


### PR DESCRIPTION
This PR merges the scoped codex-tools-1 work.

Scope included
- crates/codex-cli-acp/**
- dev-docs/** (issues, reviews, alignment records)

Out of scope (intentionally excluded)
- Unrelated configuration files and top-level docs (e.g., .claude symlink, AGENTS.md deletion)

Summary
- ACP v1 compliance: initialize/session/update, authMethods, agentCapabilities, strict validation of cwd and mcpServers.
- ToolCall lifecycle: ToolCall (initial) and ToolCallUpdate (updates) with minimal payloads and dedupe.
- Codex CLI consistency: ShellToolCallParams mapping (string/Vec<String> command, workdir, timeout, escalated permissions, justification).
- Error mapping: semantic categories mapped to ToolCallUpdate failed when in tool context.
- UTF-8-safe preview truncation with ~2KB max (prefix/suffix + marker).

Quality gates
- rustfmt/clippy/tests passing locally.

Follow-ups (to be opened on main after merge)
- Normalize JSONL fixtures to protocolVersion: 1 (ties into CI replay runner)
- Refresh doc examples (WARP.md, CLAUDE.md) to integer protocolVersion

Artifacts
- dev-docs/review/changes/codex-tools-1-review-2025-09-04.md
- dev-docs/plan/issues/acp-v1-codex-cli-alignment-and-best-practices.md
- dev-docs/plan/issues/normalize-jsonl-protocol-v1.md
- dev-docs/plan/issues/refresh-docs-examples-protocol-v1.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 提供工具调用全生命周期事件；输出/错误随事件推送，预览自动截断（约2KB，UTF‑8 安全）；自动识别工具类型；Shell 上下文（命令、工作目录、超时、权限）用于标题与位置；支持并发多工具调用与去重更新；保留完整原始输出便于调试。
- 修复
  - 预览截断遵循 UTF‑8 边界，避免多字节字符被截断。
- 测试
  - 新增单元与集成测试，覆盖映射、截断、Shell 参数与错误处理。
- 文档
  - 补充 ACP v1 对齐说明与使用示例。
- 杂务
  - 增加 JSONL 回放工件与模块导出配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->