### PR TITLE
docs(ci): SDD workflow alignment (authority, ACP v1, evidence paths, CI lint)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,10 +23,14 @@
 
 ## Checklist
 - [ ] Worktree-first (developed in dedicated worktree/branch from origin/main)
+- [ ] Branch uses canonical category (feature|fix|perf|chore|docs)
+- [ ] Spec/Plan/Tasks links included (specs/<NNN>-<slug>/...)
+- [ ] Evidence uses dev-docs/review/_artifacts/{tests,logs,jq,reports}/
 - [ ] cargo fmt --all -- --check passes
 - [ ] cargo clippy --workspace --all-targets --all-features -- -D warnings passes
 - [ ] cargo test --workspace --all-features --locked passes
 - [ ] Protocol stdout is strict JSONL; logs go to stderr
-- [ ] Evidence attached or linked
+- [ ] ACP examples (if any) use protocolVersion: 1
+- [ ] Risks & rollback section completed
 - [ ] Docs updated (CONTRIBUTING.md/CLAUDE.md/WARP.md/dev-docs)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Tests
         run: cargo test --workspace --all-features --locked
 
+      - name: SDD structure lint
+        run: bash scripts/ci/run-sdd-structure-lint.sh
+
+      - name: Language policy check (normative artifacts)
+        run: bash scripts/ci/check-language-policy.sh
+
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ RUST_LOG=debug RUST_BACKTRACE=1 cargo run -p codex-cli-acp
 
 ```bash
 # Test basic ACP handshake with Codex proto
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}' | codex proto
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}' | codex proto
 
 # Test with JSONL file containing multiple messages
 cat test/acp_messages.jsonl | codex proto -c approval_policy="never"
@@ -518,8 +518,8 @@ Stream agent responses as they're generated:
 - Example stdio stream:
 
 ```
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{}}}
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"capabilities":{}}}
 {"jsonrpc":"2.0","id":2,"method":"session/new","params":{"workingDirectory":"/path/to/project"}}
 {"jsonrpc":"2.0","id":2,"result":{"sessionId":"session_123"}}
 ```
@@ -595,7 +595,7 @@ let init_request = json!({
     "id": 1,
     "method": "initialize",
     "params": {
-        "protocolVersion": "2024-11-05",
+        "protocolVersion": 1,
         "capabilities": {
             "fs": {
                 "readTextFile": true,
@@ -719,7 +719,7 @@ ACPLB_IDLE_TIMEOUT_MS=2000 ACPLB_NOTIFY_KIND=fifo cargo run -p codex-cli-acp
 
 ```bash
 # Test initialize handshake
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}' | codex proto
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}' | codex proto
 
 # Test with custom model and permissions
 codex proto \
@@ -741,7 +741,7 @@ async fn test_acp_protocol_compliance() {
     let adapter = spawn_adapter()?;
 
     // Test initialize
-    let init_response = adapter.initialize("2024-11-05").await?;
+let init_response = adapter.initialize(1).await?;
     assert!(init_response.capabilities.contains_key("fs"));
 
     // Test session creation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ RUST_LOG=debug RUST_BACKTRACE=1 cargo run -p codex-cli-acp
 ### Testing ACP Protocol Compliance
 ```bash
 # Test basic ACP handshake with Codex proto
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}' | codex proto
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}' | codex proto
 
 # Test with JSONL file containing multiple messages
 cat test/acp_messages.jsonl | codex proto -c approval_policy="never"
@@ -472,8 +472,8 @@ Stream agent responses as they're generated:
 - No pretty-printing or multi-line JSON
 - Example stdio stream:
 ```
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{}}}
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"capabilities":{}}}
 {"jsonrpc":"2.0","id":2,"method":"session/new","params":{"workingDirectory":"/path/to/project"}}
 {"jsonrpc":"2.0","id":2,"result":{"sessionId":"session_123"}}
 ```
@@ -543,7 +543,7 @@ let init_request = json!({
     "id": 1,
     "method": "initialize",
     "params": {
-        "protocolVersion": "2024-11-05",
+        "protocolVersion": 1,
         "capabilities": {
             "fs": {
                 "readTextFile": true,
@@ -661,7 +661,7 @@ ACPLB_IDLE_TIMEOUT_MS=2000 ACPLB_NOTIFY_KIND=fifo cargo run -p codex-cli-acp
 ### Testing ACP Compliance
 ```bash
 # Test initialize handshake
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}' | codex proto
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}' | codex proto
 
 # Test with custom model and permissions
 codex proto \
@@ -682,7 +682,7 @@ async fn test_acp_protocol_compliance() {
     let adapter = spawn_adapter()?;
     
     // Test initialize
-    let init_response = adapter.initialize("2024-11-05").await?;
+let init_response = adapter.initialize(1).await?;
     assert!(init_response.capabilities.contains_key("fs"));
     
     // Test session creation

--- a/WARP.md
+++ b/WARP.md
@@ -1,44 +1,97 @@
 # WARP.md
 
-WARP Agent is the terminal-side AI developer operating in this repository. This document defines WARP’s role, scope, and operating rules so that its work is predictable, auditable, and compatible with our team workflow.
+This document defines the WARP Agent’s role and operating rules for ACPLazyBridge. It is a role-specific guide. For the authoritative workflow and lifecycle, always refer to the documents listed below.
 
-⚠️ ACPLazyBridge related interface design & implementation must strictly follow ACP specifications & check Codex CLI parameters!
-**ACP-DocsAndSourceCodeReference**: [ACP-DocsAndSourceCodeReference.md](ACP-DocsAndSourceCodeReference.md)
+Authority and scope
+- Normative authority:
+  - CONTRIBUTING.md (engineering ground rules)
+  - sdd-rules/spec-driven.md (SDD principles & workflow)
+  - sdd-rules/lifecycle.md (SDD-driven lifecycle)
+- Team/agent rules:
+  - sdd-rules/AGENTS.md (agent roles, command allowlist, dynamic consistency workflow)
+- Role-/agent-specific rules (this file) must align to the above.
+- Non-normative engineering references: dev-docs/engineering/* (each file is bannered and links back to the authority)
 
-Role & Responsibilities
+Language policy
+- All normative artifacts committed to the repository (PRDs, specifications, plans, issues, task templates) MUST be in English.
+- Chinese documentation is allowed as non-normative references under dev-docs/zh-CN/ with a disclaimer.
+- Conversations may use other languages.
+
+Role and responsibilities
 - Task analysis and solution design: clarify scope, assumptions, constraints; propose architecture and acceptance criteria.
 - Planning: break down issues into executable tasks with traceability to requirements/spec/design.
 - Local verification: build, lint, test; replay protocol JSONL scenarios; produce logs and evidence.
 - Code review support: summarize diffs, risks, and evidence; recommend merge or changes.
 - Merge execution: when authorized, perform non-interactive merges (squash), respecting protected-branch rules.
 
-Operating Rules
-- Tools: Only use terminal commands in the repo; avoid interactive/paged commands; never expose secrets.
-- Worktree-first: never develop on main; create feature/* branches in dedicated worktrees.
-- Logging discipline: stderr for logs; stdout reserved for JSON-RPC/JSONL.
-- Evidence: save scenario outputs and jq validations under _artifacts/logs/<task>/ or CI artifacts.
-- Respect human edits: do not override user modifications unless explicitly asked; reconcile conflicts conservatively.
+Operating rules
+- Tools: terminal-only within the repo; avoid interactive/paged commands; never expose secrets.
+- Command allowlist & MCP servers: defer to sdd-rules/AGENTS.md; do not duplicate here.
+- Worktree-first: never develop on main; create a feature branch in a dedicated worktree.
+- Branch categories (canonical): feature | fix | perf | chore | docs (kebab-case). The feature/<module>-<id> style is allowed as an alternative but not the canonical example.
+- Logging discipline: stderr for logs; stdout reserved for JSON-RPC/JSONL only.
+- Evidence: store all local scenario outputs and jq validations under dev-docs/review/_artifacts/{tests,logs,jq,reports}/<task>/.
+- Respect human edits: do not override user modifications unless explicitly requested; reconcile conflicts conservatively.
 
-Standard Procedure
+SDD compliance (must do for every task)
+- Create an SDD record under specs/<NNN>-<slug>/ with:
+  - spec.md (WHAT/WHY; requirements and acceptance)
+  - plan.md (technical plan; architecture and trade-offs)
+  - tasks.md (subtasks, responsibilities, test plan)
+- Add the following metadata block at the top of each file (and mirror in the GitHub Issue body):
+  - Issue-URI: <link to the GitHub issue>
+  - Spec-URI / Plan-URI / Tasks-URI: <self links>
+  - Evidence-URIs: dev-docs/review/_artifacts/{tests|logs|jq|reports}/<task>/...
+- PR description must include: links to Spec/Plan/Tasks, evidence files (tests/logs/jq/reports), risks/rollback, and CI pass summary.
+
+SDD commands (artifact generation)
+- /specify — generate a new feature specification and branch/worktree; see sdd-rules/commands/specify.md
+- /plan — create implementation plan and design docs; see sdd-rules/commands/plan.md
+- /tasks — derive executable tasks from the plan; see sdd-rules/commands/tasks.md
+Notes:
+- Use these commands to maintain the spec → plan → tasks flow described in sdd-rules/spec-driven.md and sdd-rules/lifecycle.md.
+
+Standard procedure
 1) Context gathering
    - Inspect repository state, read relevant files, and list existing workflows.
 2) Plan tasks
    - Draft a concise checklist; create a feature worktree from origin/main.
 3) Implement & verify
-   - Code changes via patch; run cargo fmt/clippy/test; replay JSONL scenarios.
+   - Code changes via patch; run fmt/clippy/test; replay JSONL scenarios; record evidence.
 4) Evidence
-   - Store outputs and logs; summarize pass/fail and link artifacts.
+   - Store outputs and logs under dev-docs/review/_artifacts/...; summarize pass/fail and link artifacts.
 5) PR & merge
    - Open PR with summary and evidence; on approval, squash-merge and clean up worktrees.
+   - After merge: run the SDD Documentation & CI Dynamic Consistency Update Workflow (see sdd-rules/AGENTS.md) to resync docs/templates if needed.
 
-Quality Gates (must pass)
+Branch and worktree (canonical example)
+- Branch categories: feature | fix | perf | chore | docs
+- Create a new worktree and branch from origin/main:
+  git -C /Users/arthur/dev-space/ACPLazyBridge worktree add /Users/arthur/dev-space/acplb-worktrees/<task-dir> origin/main -b <branch>
+- Optional IDE navigation:
+  ln -sfn /Users/arthur/dev-space/acplb-worktrees/<task-dir> /Users/arthur/dev-space/ACPLazyBridge/.worktrees/<task-dir>
+
+Quality gates (must pass)
 - cargo fmt --all -- --check
 - cargo clippy --workspace --all-targets --all-features -- -D warnings
 - cargo test --workspace --all-features --locked
 - Protocol JSONL scenarios (if present) replay without errors; stdout is valid JSONL.
-- CodeQL security analysis (automated in CI). See `dev-docs/engineering/codeql.md` for custom queries.
+- Code scanning (GitHub Code Scanning) is enabled. For local custom CodeQL queries, see dev-docs/engineering/codeql.md.
 
-Security & Compliance
+Constitutional gates (must pass)
+- Simplicity (Article VII): ≤3 projects; no future-proofing; avoid unnecessary patterns.
+- Anti-Abstraction (Article VIII): Use framework features directly; single model representation.
+- Integration-First (Article IX): Contracts defined; contract tests written before implementation; use real dependencies where practical.
+- Test-First (Article III): Write tests first and confirm failing (RED) before implementation.
+
+Local docs & SDD checks (pre-PR)
+- scripts/ci/run-local-ci.sh — runs structure, language, markdown, and semantic checks
+- Or on macOS, run individually:
+  - scripts/sdd/check_language.sh
+  - scripts/sdd/lint_docs.sh
+  - scripts/sdd/run_semantic_checks.sh
+
+Security & compliance
 - Do not log secrets; never print secrets to CI logs; use env vars and GitHub secrets.
 - Avoid running untrusted code or scripts without review.
 
@@ -47,400 +100,77 @@ Communication
 - Escalate risks with options and trade-offs.
 
 References
-- See CONTRIBUTING.md for team workflow and CI/CD rules.
-- See CLAUDE.md for Claude Code development policy.
-### Plugin System (Planned)
-The architecture includes plans for an extensible plugin system:
-- Inbound/outbound processing chains
-- Sub-agent invocation capabilities
-- TOML/YAML configuration
-- Example plugins: translation, prompt optimization
+- Authority: CONTRIBUTING.md, sdd-rules/spec-driven.md, sdd-rules/lifecycle.md, sdd-rules/AGENTS.md
+- SDD templates: sdd-rules/spec-template.md, sdd-rules/plan-template.md, sdd-rules/tasks-template.md
+- SDD commands: sdd-rules/commands/specify.md, sdd-rules/commands/plan.md, sdd-rules/commands/tasks.md
+- Project references: dev-docs/references/, dev-docs/references/acp_adapters/, dev-docs/references/cli_agents/, dev-docs/references/acp.md, dev-docs/references/zed_ide.md
+- Design/Plan/Requirements: dev-docs/design/, dev-docs/plan/, dev-docs/requirements/
 
-## Implementation Status
+Implementation status
+- Completed (M0): Rust workspace bootstrapped; references vendored
+- In progress (M1): Codex native adapter (stdio loop, streaming, tool calls, permission mapping, smoke testing)
+- Planned: Proxy adapter, plugin system v0, native adapters, HTTP/SSE bridge
 
-### Completed (M0)
-- Rust workspace setup with two crates
-- Basic project structure and dependencies
-- Reference materials vendored
-
-### In Progress (M1 - Codex Native Adapter)
-- ACP stdio loop implementation
-- Streaming and tool call support
-- Permission mapping
-- Smoke testing
-
-### Planned
-- M2: Proxy adapter for Claude/Gemini
-- M3: Plugin system v0
-- M4: Native Claude/Gemini adapters
-- M5: HTTP/SSE bridge for non-ACP editors
-
-## Protocol Implementation Guidelines
-
-### JSON-RPC 2.0 Message Structure
-All ACP messages must follow JSON-RPC 2.0 format:
-
-#### Request Message
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "initialize",
-  "params": {
-    "protocolVersion": "2024-11-05",
-    "capabilities": {}
-  }
-}
-```
-
-#### Response Message
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "protocolVersion": "2024-11-05",
-    "capabilities": {},
-    "serverInfo": {
-      "name": "codex-cli-acp",
-      "version": "0.1.0"
-    }
-  }
-}
-```
-
-#### Notification Message (No ID)
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "session/update",
-  "params": {
-    "sessionId": "session_123",
-    "content": "Processing request..."
-  }
-}
-```
-
-#### Error Response
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "error": {
-    "code": -32600,
-    "message": "Invalid Request",
-    "data": "Additional error details"
-  }
-}
-```
-
-### Event Streaming Specifications
-
-#### Agent Message Chunks
-Stream agent responses as they're generated:
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "session/update",
-  "params": {
-    "sessionId": "session_123",
-    "type": "agent_message_chunk",
-    "content": "Here's the analysis of your code..."
-  }
-}
-```
-
-#### Tool Call Events
-##### Pending State
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "session/update",
-  "params": {
-    "sessionId": "session_123",
-    "type": "tool_call",
-    "toolCallId": "tool_456",
-    "name": "fs/read_text_file",
-    "arguments": {
-      "path": "/absolute/path/to/file.rs"
-    },
-    "status": "pending"
-  }
-}
-```
-
-##### Completed State
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "session/update",
-  "params": {
-    "sessionId": "session_123",
-    "type": "tool_call",
-    "toolCallId": "tool_456",
-    "status": "completed",
-    "result": {
-      "content": "file contents here..."
-    }
-  }
-}
-```
-
-### JSONL Communication Format
-- Each JSON message is on a single line
-- Lines are terminated with `\n`
-- No pretty-printing or multi-line JSON
-- Example stdio stream:
-```
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}
-{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{}}}
-{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"workingDirectory":"/path/to/project"}}
-{"jsonrpc":"2.0","id":2,"result":{"sessionId":"session_123"}}
-```
-
-### Error Handling Requirements
-- Use standard JSON-RPC 2.0 error codes:
-  - `-32700`: Parse error
-  - `-32600`: Invalid Request
-  - `-32601`: Method not found
-  - `-32602`: Invalid params
-  - `-32603`: Internal error
-- Include descriptive error messages
-- Add optional `data` field for debugging details
-
-## Development Guidelines
-
-### Adding a New Adapter
-1. Create new crate under `crates/` (e.g., `crates/gemini-acp/`)
-2. Add to workspace members in root `Cargo.toml`
-3. Implement ACP server protocol using `acp-lazy-core` utilities
-4. Add binary entry point with stdio handling
-5. Map provider-specific events to ACP events
-6. Add tests and documentation
-
-### Debugging Tips
-- Enable debug logging: `RUST_LOG=debug`
-- Capture full backtraces: `RUST_BACKTRACE=full`
-- Monitor stderr for provider subprocess output
-- Use `tracing` macros for structured logging
-- Check `dev-docs/` for Chinese language design documentation
-
-### Testing Strategy
-- Unit tests: Protocol parsing, permission mapping, event de-duplication
-- Integration tests: Mock stdout event sequences, tool call flows
-- Smoke tests: Real provider integration with actual API calls
-
-## Practical Examples
-
-### Spawning Codex in Proto Mode
-```rust
-use std::process::{Command, Stdio};
-use std::io::{BufReader, BufWriter, BufRead, Write};
-
-// Spawn Codex CLI in proto mode with appropriate permissions
-let mut child = Command::new("codex")
-    .arg("proto")
-    .arg("-c")
-    .arg("approval_policy=never")
-    .arg("-c")
-    .arg("sandbox_mode=workspace-write")
-    .stdin(Stdio::piped())
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped())
-    .spawn()?;
-
-let stdin = BufWriter::new(child.stdin.take().unwrap());
-let stdout = BufReader::new(child.stdout.take().unwrap());
-```
-
-### Sample ACP Session Flow
-
-#### 1. Initialize Connection
-```rust
-// Send initialize request
-let init_request = json!({
+Protocol implementation guidelines (ACP v1 examples)
+- All examples use ACP v1: "protocolVersion": 1
+- JSON-RPC 2.0 message structure:
+  Request:
+  {
     "jsonrpc": "2.0",
     "id": 1,
     "method": "initialize",
-    "params": {
-        "protocolVersion": "2024-11-05",
-        "capabilities": {
-            "fs": {
-                "readTextFile": true,
-                "writeTextFile": true
-            }
-        }
-    }
-});
-writeln!(stdin, "{}", init_request)?;
-
-// Read initialize response
-let response: String = stdout.read_line()?;
-// Parse response and extract server capabilities
-```
-
-#### 2. Create New Session
-```rust
-let new_session = json!({
+    "params": { "protocolVersion": 1, "capabilities": {} }
+  }
+  Response:
+  {
     "jsonrpc": "2.0",
-    "id": 2,
-    "method": "session/new",
-    "params": {
-        "workingDirectory": "/absolute/path/to/project",
-        "mcpServers": []  // Optional MCP server configurations
+    "id": 1,
+    "result": {
+      "protocolVersion": 1,
+      "capabilities": {},
+      "serverInfo": { "name": "codex-cli-acp", "version": "0.1.0" }
     }
-});
-writeln!(stdin, "{}", new_session)?;
-```
-
-#### 3. Send Prompt and Handle Streaming
-```rust
-let prompt = json!({
+  }
+  Notification:
+  {
     "jsonrpc": "2.0",
-    "id": 3,
-    "method": "session/prompt",
-    "params": {
-        "sessionId": "session_123",
-        "prompt": "Analyze the main.rs file and suggest improvements",
-        "includeWorkspaceContext": true
-    }
-});
-writeln!(stdin, "{}", prompt)?;
+    "method": "session/update",
+    "params": { "sessionId": "session_123", "content": "Processing request..." }
+  }
+  Error:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "error": { "code": -32600, "message": "Invalid Request", "data": "Additional error details" }
+  }
 
-// Process streaming updates
-loop {
-    let line = stdout.read_line()?;
-    let msg: Value = serde_json::from_str(&line)?;
-    
-    if msg["method"] == "session/update" {
-        match msg["params"]["type"].as_str() {
-            Some("agent_message_chunk") => {
-                // Display agent response chunk
-                print!("{}", msg["params"]["content"]);
-            }
-            Some("tool_call") => {
-                // Handle tool call
-                let status = msg["params"]["status"].as_str();
-                if status == Some("pending") {
-                    // Tool call started
-                } else if status == Some("completed") {
-                    // Tool call finished
-                }
-            }
-            _ => {}
-        }
-    } else if msg["id"] == 3 {
-        // Final response received
-        break;
-    }
-}
-```
+Event streaming specifications
+- Agent message chunks: session/update with type=agent_message_chunk
+- Tool call events: pending → completed tool_call updates
 
-### Testing ACP Compliance
-```bash
-# Test initialize handshake
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}' | codex proto
+JSONL communication format
+- One JSON message per line; newline-terminated; no pretty-printing
 
-# Test with custom model and permissions
-codex proto \
-  -c model="openai/gpt-5" \
-  -c approval_policy="never" \
-  -c sandbox_mode="read-only" \
-  < test_messages.jsonl
+Error handling requirements
+- Use standard JSON-RPC 2.0 error codes:
+  - -32700 Parse error
+  - -32600 Invalid Request
+  - -32601 Method not found
+  - -32602 Invalid params
+  - -32603 Internal error
+- Include descriptive messages and optional data field
 
-# Debug with verbose logging
-RUST_LOG=debug codex proto 2>debug.log
-```
+Practical examples (updated to ACP v1)
+- Test initialize handshake:
+  echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}' | codex proto
+- With custom model and permissions:
+  codex proto -c model="openai/gpt-5" -c approval_policy="never" -c sandbox_mode="read-only" < test_messages.jsonl
+- Debug with verbose logging:
+  RUST_LOG=debug codex proto 2>debug.log
 
-### Integration Test Example
-```rust
-#[tokio::test]
-async fn test_acp_protocol_compliance() {
-    // Spawn codex-cli-acp adapter
-    let adapter = spawn_adapter()?;
-    
-    // Test initialize
-    let init_response = adapter.initialize("2024-11-05").await?;
-    assert!(init_response.capabilities.contains_key("fs"));
-    
-    // Test session creation
-    let session = adapter.new_session("/test/project").await?;
-    assert!(!session.id.is_empty());
-    
-    // Test prompt with streaming
-    let mut stream = adapter.prompt(&session.id, "test prompt").await?;
-    
-    let mut chunks = vec![];
-    while let Some(update) = stream.next().await {
-        match update.type {
-            UpdateType::AgentMessageChunk(text) => chunks.push(text),
-            UpdateType::ToolCall(call) => {
-                // Verify tool call format
-                assert!(call.id.starts_with("tool_"));
-            }
-            _ => {}
-        }
-    }
-    
-    assert!(!chunks.is_empty());
-}
-```
+Non-mock testing plan (WARP-Agent + Zed smoke)
+- Evidence path: dev-docs/review/_artifacts/{tests,logs,jq,reports}/<task>/
+- Do not echo secrets; use environment variables (e.g., ANTHROPIC_API_KEY, GEMINI_API_KEY)
 
-## References
-
-- ACP Specification: See `local_refs/agent-client-protocol/`
-- Zed Examples: See `local_refs/zed-acp-examples/`
-- Codex Documentation: See `local_refs/codex/`
-- Design Docs: See `dev-docs/design/acp-lazybridge-architecture.md` (Chinese)
-- Project Plan: See `dev-docs/plan/acp-lazybridge-project-plan.md` (Chinese)
-- Requirements: See `dev-docs/requirements/acp-lazybridge-requirements.md` (Chinese)
-
-## Important Notes
-
-- The project strictly follows ACP specifications - check `local_refs/` for reference
-- Default configuration uses non-interactive approvals to prevent IDE stalls
-- YOLO/danger-full-access mode must be explicitly opted into
-- Chinese documentation in `dev-docs/` contains detailed implementation guidance
-
-## Troubleshooting
-
-- **Build failures**: Run `cargo clean` and verify Rust stable toolchain
-- **Protocol issues**: Enable `RUST_LOG=debug` and examine stdout/stderr
-- **Permission errors**: Check permission mapping configuration
-- **Streaming issues**: Verify line-based JSON format and de-duplication logic
-
-## Non-mock Testing Plan (WARP-Agent + Zed smoke)
-
-Scope
-- Scripted tests executed by WARP-Agent using JSONL scenarios against real provider CLIs.
-- Manual smoke in Zed configured to use ACPLazyBridge binaries.
-
-Prerequisites
-- Codex CLI installed and configured (~/.codex/config.toml)
-- Build adapter: `cargo build --release -p codex-cli-acp`
-- Zed installed and configured (~/.config/zed/settings.json)
-- Future (post-merge): `claude-code-acplb` and `gemini-cli-acplb` binaries available
-
-Scripted runs (Codex)
-- Scenarios live in `dev-docs/review/_artifacts/tests/`
-- Example run (persist logs):
-  - `target/release/codex-cli-acp < dev-docs/review/_artifacts/tests/handshake.jsonl | tee dev-docs/review/_artifacts/logs/run_$(date +%Y%m%d_%H%M%S).log`
-- Optional jq snapshots per `dev-docs/review/_artifacts/jq/filters.md`
-
-Zed manual smoke
-- Point `~/.config/zed/settings.json` → ACPLazyBridge (Codex): absolute path to `target/release/codex-cli-acp`
-- Keep Claude/Gemini entries disabled until their binaries exist
-- Save full run output to `dev-docs/review/_artifacts/logs/` per logs/README.md
-
-Acceptance checklist
-- initialize negotiates protocolVersion and promptCapabilities.image=false
-- new session returns a non-empty sessionId
-- prompt streams session/update(type=agent_message_chunk) and ends with result.stopReason
-- cancel leads to stopReason=Cancelled
-
-Secrets
-- Never echo secrets. Use env vars (e.g., `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`) set in the shell; do not print them.
-
-References
-- See CONTRIBUTING.md for repo-wide policy and evidence rules
-- See CLAUDE.md for Claude Code–specific setup to be enabled post-merge
+Notes
+- This file is role-specific. If it conflicts with CONTRIBUTING.md or sdd-rules/lifecycle.md, those take precedence.

--- a/dev-docs/plan/issues/TEMPLATE.md
+++ b/dev-docs/plan/issues/TEMPLATE.md
@@ -43,10 +43,10 @@ Title: <module> - <serial number> - <sentence objective>
 - ZED: ...
 
 ## Acceptance Criteria
-- Test cases: _artifacts/tests/<file>.jsonl
-- Log evidence: _artifacts/logs/<run_yyyymmdd_hhmmss>.log + jq filter script
+- Test cases: dev-docs/review/_artifacts/tests/<file>.jsonl
+- Log evidence: dev-docs/review/_artifacts/logs/<run_yyyymmdd_hhmmss>.log + jq filter script
 
 ## Worktree-first
 - Branch: feature/<module>-<serial number>
-- Initialize: git worktree add ../<module>-<serial number> feature/<module>-<serial number>
+- Initialize: git worktree add ../<module>-<serial number> origin/main -b feature/<module>-<serial number>
 - Merge: via PR to main repo; ensure traceability.csv is updated to Verified/Partial, no orphan entries

--- a/dev-docs/plan/issues/m1-issue-list.md
+++ b/dev-docs/plan/issues/m1-issue-list.md
@@ -26,7 +26,7 @@
 - 状态：✅ 已完成（acp-lazy-core::transport 实现 + 单测通过；stderr 日志分级与退出尾日志保留）
 - Worktree 指南
   - 分支名：feature/core-transport-1
-  - git worktree add ../acplb-core-transport-1 feature/core-transport-1
+  - git worktree add ../acplb-core-transport-1 origin/main -b feature/core-transport-1
 
 ## ISSUE: core-permissions-1 — ACP→Codex 权限映射
 - 需求
@@ -138,7 +138,7 @@
 - 需求
   - 新增 large_output/tool_calls 用例；完善 logs/README 与 jq 过滤
 - 技术方案
-  - 统一在 _artifacts/tests 归档；输出快照存 logs
+  - 统一在 dev-docs/review/_artifacts/tests 归档；输出快照存 dev-docs/review/_artifacts/logs
 - local_refs 引用
   - (local_refs/zed-acp-examples)
 - 对应 review 条目

--- a/dev-docs/references/acp.md
+++ b/dev-docs/references/acp.md
@@ -1,0 +1,39 @@
+# Agent Client Protocol (ACP) Reference
+
+This document contains links to the official documentation, source code, and other resources for the Agent Client Protocol (ACP).
+
+## Official Resources
+
+- **Website:** [https://agentclientprotocol.com/](https://agentclientprotocol.com/)
+- **GitHub Repository:** [https://github.com/zed-industries/agent-client-protocol](https://github.com/zed-industries/agent-client-protocol)
+
+## Schema
+
+- **Meta Schema:** [meta.json](https://github.com/zed-industries/agent-client-protocol/blob/main/schema/meta.json)
+- **JSON Schema:** [schema.json](https://github.com/zed-industries/agent-client-protocol/blob/main/schema/schema.json)
+
+## Protocol Documentation
+
+The official documentation provides a comprehensive overview of the protocol.
+
+### Overview
+- **Introduction:** [introduction.mdx](https://github.com/zed-industries/agent-client-protocol/blob/main/docs/overview/introduction.mdx)
+- **Architecture:** [architecture.mdx](https://github.com/zed-industries/agent-client-protocol/blob/main/docs/overview/architecture.mdx)
+
+### Protocol Details
+- **Overview:** [overview.mdx](https://github.com/zed-industries/agent-client-protocol/blob/main/docs/protocol/overview.mdx)
+- **Schema:** [schema.mdx](https://github.com/zed-industries/agent-client-protocol/blob/main/docs/protocol/schema.mdx)
+- **Initialization:** [initialization.mdx](https://github.com/zed-industries/agent-client-protocol/blob/main/docs/protocol/initialization.mdx)
+- **Session Setup:** [session-setup.mdx](https://github.com/zed-industries/agent-client-protocol/blob/main/docs/protocol/session-setup.mdx)
+- **Prompt & Turn:** [prompt-turn.mdx](https://github.com/zed-industries/agent-client-protocol/blob/main/docs/protocol/prompt-turn.mdx)
+- **Agent Plan:** [agent-plan.mdx](https://github.com/zed-industries/agent-client-protocol/blob/main/docs/protocol/agent-plan.mdx)
+- **Content:** [content.mdx](https://github.com/zed-industries/agent-client-protocol/blob/main/docs/protocol/content.mdx)
+- **Tool Calls:** [tool-calls.mdx](https://github.com/zed-industries/agent-client-protocol/blob/main/docs/protocol/tool-calls.mdx)
+- **File System:** [file-system.mdx](https://github.com/zed-industries/agent-client-protocol/blob/main/docs/protocol/file-system.mdx)
+
+## Rust Implementation
+
+- **Crate:** `agent-client-protocol = "0.1.1"`
+- **Docs.rs:** [https://docs.rs/agent-client-protocol/0.1.1/agent_client_protocol/](https://docs.rs/agent-client-protocol/0.1.1/agent_client_protocol/)
+- **Example Agent:** [example_agent.rs](https://github.com/zed-industries/agent-client-protocol/blob/main/rust/example_agent.rs)
+- **Example Client:** [example_client.rs](https://github.com/zed-industries/agent-client-protocol/blob/main/rust/example_client.rs)

--- a/dev-docs/references/acp_adapters/claude_code_acp.md
+++ b/dev-docs/references/acp_adapters/claude_code_acp.md
@@ -1,0 +1,18 @@
+# Claude Code ACP Adapter Reference
+
+This document contains links to the official source code and packages for the `claude-code-acp` adapter by Zed Industries.
+
+This adapter allows an [ACP-compatible client](https://agentclientprotocol.com/) (like the Zed IDE) to communicate with the [Claude Code CLI](https://docs.anthropic.com/s/claude-code).
+
+## Official Resources
+
+- **GitHub Repository:** [https://github.com/zed-industries/claude-code-acp](https://github.com/zed-industries/claude-code-acp)
+- **NPM Package:** [@zed-industries/claude-code-acp](https://www.npmjs.com/package/@zed-industries/claude-code-acp)
+
+## Source Code
+
+The main logic for the adapter is contained in the `src/` directory.
+
+- **Source Directory:** [src/](https://github.com/zed-industries/claude-code-acp/tree/main/src)
+- **Main Entrypoint:** [src/index.ts](https://github.com/zed-industries/claude-code-acp/blob/main/src/index.ts)
+- **ACP Agent Implementation:** [src/acp-agent.ts](https://github.com/zed-industries/claude-code-acp/blob/main/src/acp-agent.ts)

--- a/dev-docs/references/cli_agents/claude_code.md
+++ b/dev-docs/references/cli_agents/claude_code.md
@@ -1,0 +1,22 @@
+# Claude Code CLI Reference
+
+This document contains links to the official documentation and source code for the Anthropic Claude Code CLI.
+
+## Official Resources
+
+- **GitHub Repository:** [https://github.com/anthropics/claude-code](https://github.com/anthropics/claude-code)
+- **Official Documentation:** [https://docs.anthropic.com/en/docs/claude-code/overview](https://docs.anthropic.com/en/docs/claude-code/overview)
+- **NPM Package:** [@anthropic-ai/claude-code](https://www.npmjs.com/package/@anthropic-ai/claude-code)
+- **Primary Interface:** `claude` CLI tool.
+
+## Key Documentation Topics
+
+The official documentation website is the best source of information. Here are links to some of the most relevant sections.
+
+- **CLI Reference:** [https://docs.anthropic.com/en/docs/claude-code/cli-reference](https://docs.anthropic.com/en/docs/claude-code/cli-reference)
+- **Slash Commands:** [https://docs.anthropic.com/en/docs/claude-code/slash-commands](https://docs.anthropic.com/en/docs/claude-code/slash-commands)
+- **Hooks:** [https://docs.anthropic.com/en/docs/claude-code/hooks](https://docs.anthropic.com/en/docs/claude-code/hooks)
+- **SDK Overview:** [https://docs.anthropic.com/en/docs/claude-code/sdk/overview](https://docs.anthropic.com/en/docs/claude-code/sdk/overview)
+- **Configuration:** The tool is configured via `~/.claude/settings.json`.
+
+*Note: The local configuration file for this project's integration is `dev-docs/coding-agents-cli-config/ClaudeCode/ClaudeCode-Config.md`.*

--- a/dev-docs/references/cli_agents/codex.md
+++ b/dev-docs/references/cli_agents/codex.md
@@ -1,0 +1,31 @@
+# Codex CLI Reference
+
+This document contains links to the official documentation and source code for the OpenAI Codex CLI.
+
+## Official Resources
+
+- **GitHub Repository:** [https://github.com/openai/codex](https://github.com/openai/codex)
+- **Primary Interface:** `codex` CLI tool.
+
+## Source Code
+
+- **CLI (TypeScript):** [codex-cli/](https://github.com/openai/codex/tree/main/codex-cli)
+- **Core (Rust):** [codex-rs/](https://github.com/openai/codex/tree/main/codex-rs)
+
+## Documentation
+
+The official documentation is located in the `docs/` directory of the repository.
+
+- **Getting Started:** [getting-started.md](https://github.com/openai/codex/blob/main/docs/getting-started.md)
+- **Advanced Usage:** [advanced.md](https://github.com/openai/codex/blob/main/docs/advanced.md)
+- **Authentication:** [authentication.md](https://github.com/openai/codex/blob/main/docs/authentication.md)
+- **Configuration:** [config.md](https://github.com/openai/codex/blob/main/docs/config.md)
+- **Installation:** [install.md](https://github.com/openai/codex/blob/main/docs/install.md)
+- **Platform Sandboxing:** [platform-sandboxing.md](https://github.com/openai/codex/blob/main/docs/platform-sandboxing.md)
+- **Prompts:** [prompts.md](https://github.com/openai/codex/blob/main/docs/prompts.md)
+- **Sandbox:** [sandbox.md](https://github.com/openai/codex/blob/main/docs/sandbox.md)
+- **Zero Data Retention (ZDR):** [zdr.md](https://github.com/openai/codex/blob/main/docs/zdr.md)
+- **Contributing:** [contributing.md](https://github.com/openai/codex/blob/main/docs/contributing.md)
+- **FAQ:** [faq.md](https://github.com/openai/codex/blob/main/docs/faq.md)
+
+*Note: The local configuration file for this project's integration is `dev-docs/coding-agents-cli-config/CodexCLI/CodexCLI-Config.md`.*

--- a/dev-docs/references/cli_agents/gemini.md
+++ b/dev-docs/references/cli_agents/gemini.md
@@ -1,0 +1,21 @@
+# Gemini CLI Reference
+
+This document contains links to the official documentation and source code for the Google Gemini CLI.
+
+## Official Resources
+
+- **GitHub Repository:** [https://github.com/google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli)
+- **Official Documentation Site:** [https://google-gemini.github.io/gemini-cli/](https://google-gemini.github.io/gemini-cli/)
+- **NPM Package:** [@google/gemini-cli](https://www.npmjs.com/package/@google/gemini-cli)
+- **Primary Interface:** `gemini` CLI tool.
+
+## Key Documentation Topics
+
+The official documentation is located in the `docs/` directory of the repository and is also available as a rendered website.
+
+- **Documentation Index:** [docs/cli/index.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/index.md)
+- **Authentication:** [docs/cli/authentication.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/authentication.md)
+- **Configuration:** [docs/cli/configuration.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md)
+- **Commands Reference:** [docs/cli/commands.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/commands.md)
+- **Built-in Tools Overview:** [docs/tools/index.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/index.md)
+- **MCP Server Integration:** [docs/tools/mcp-server.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)

--- a/dev-docs/references/zed_ide.md
+++ b/dev-docs/references/zed_ide.md
@@ -1,0 +1,36 @@
+# Zed IDE - ACP Integration Reference
+
+This document contains links to the source code within the Zed IDE repository that are relevant to its implementation of the Agent Client Protocol (ACP).
+
+## Official Resources
+
+- **Website:** [https://zed.dev/](https://zed.dev/)
+- **GitHub Repository:** [https://github.com/zed-industries/zed](https://github.com/zed-industries/zed)
+
+## Core ACP Implementation
+
+These files represent the core logic for handling ACP agents within Zed. The user's original local paths pointed to a vendored copy of these files.
+
+- **ACP Protocol Handling:**
+  - `crates/agent/src/acp.rs`
+  - **URL:** [https://github.com/zed-industries/zed/blob/main/crates/agent/src/acp.rs](https://github.com/zed-industries/zed/blob/main/crates/agent/src/acp.rs)
+
+- **Agent Server Management:**
+  - `crates/agent/src/agent_servers.rs`
+  - **URL:** [https://github.com/zed-industries/zed/blob/main/crates/agent/src/agent_servers.rs](https://github.com/zed-industries/zed/blob/main/crates/agent/src/agent_servers.rs)
+
+## Specific Agent Implementations
+
+These files show how specific external CLI tools are integrated as agents.
+
+- **Claude Agent:**
+  - `crates/agent/src/agents/claude.rs`
+  - **URL:** [https://github.com/zed-industries/zed/blob/main/crates/agent/src/agents/claude.rs](https://github.com/zed-industries/zed/blob/main/crates/agent/src/agents/claude.rs)
+
+- **Gemini Agent:**
+  - `crates/agent/src/agents/gemini.rs`
+  - **URL:** [https://github.com/zed-industries/zed/blob/main/crates/agent/src/agents/gemini.rs](https://github.com/zed-industries/zed/blob/main/crates/agent/src/agents/gemini.rs)
+
+- **Custom Agent:**
+  - `crates/agent/src/agents/custom.rs`
+  - **URL:** [https://github.com/zed-industries/zed/blob/main/crates/agent/src/agents/custom.rs](https://github.com/zed-industries/zed/blob/main/crates/agent/src/agents/custom.rs)

--- a/dev-docs/sdd/README.md
+++ b/dev-docs/sdd/README.md
@@ -1,0 +1,8 @@
+# SDD Index
+
+This folder provides a thin index for the SDD lifecycle and templates. The authoritative rules and templates live in sdd-rules/.
+
+- Lifecycle: see sdd-rules/lifecycle.md
+- Templates: sdd-rules/spec-template.md, sdd-rules/plan-template.md, sdd-rules/tasks-template.md
+- Global rules: sdd-rules/AGENTS.md, sdd-rules/CLAUDE.md
+

--- a/dev-docs/sdd/lifecycle.md
+++ b/dev-docs/sdd/lifecycle.md
@@ -1,0 +1,4 @@
+# Lifecycle
+
+For the authoritative lifecycle, see ../../sdd-rules/lifecycle.md
+

--- a/scripts/ci/check-language-policy.sh
+++ b/scripts/ci/check-language-policy.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Heuristic language check: normative artifacts under sdd-rules/ must be English-only
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+cd "$ROOT_DIR"
+
+fail=false
+err() { echo "[LANG] ERROR: $*" >&2; fail=true; }
+info() { echo "[LANG] $*"; }
+
+# Use Python to detect CJK characters in sdd-rules/*.md
+python3 - <<'PY'
+import sys, pathlib, re
+root = pathlib.Path('.')
+cjk = re.compile(r"[\u4E00-\u9FFF]")
+violations = []
+for p in sorted((root / 'sdd-rules').glob('*.md')):
+    text = p.read_text(encoding='utf-8', errors='ignore')
+    if cjk.search(text):
+        violations.append(str(p))
+if violations:
+    print('[LANG] ERROR: CJK characters found in normative artifacts:')
+    for v in violations:
+        print('[LANG]  -', v)
+    sys.exit(1)
+print('[LANG] sdd-rules English-only check passed')
+PY
+
+$fail && exit 1 || exit 0
+

--- a/scripts/ci/run-sdd-structure-lint.sh
+++ b/scripts/ci/run-sdd-structure-lint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Minimal SDD structure lint
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+cd "$ROOT_DIR"
+
+fail=false
+err() { echo "[SDD-LINT] ERROR: $*" >&2; fail=true; }
+info() { echo "[SDD-LINT] $*"; }
+
+# 1) Required authoritative files
+for f in sdd-rules/AGENTS.md sdd-rules/CLAUDE.md sdd-rules/lifecycle.md sdd-rules/spec-driven.md sdd-rules/spec-template.md sdd-rules/plan-template.md sdd-rules/tasks-template.md; do
+  if [ ! -f "$f" ]; then err "missing $f"; fi
+done
+
+# 2) No outdated protocol version examples
+if grep -Rni --include='*.md' 'protocolVersion":"2024-11-05"' . >/dev/null; then
+  err "found outdated protocolVersion examples (2024-11-05); use integer 1"
+fi
+
+# 3) Evidence path hints (at least appears somewhere)
+if ! grep -Rni --include='*.md' 'dev-docs/review/_artifacts' . >/dev/null; then
+  err "evidence path 'dev-docs/review/_artifacts' not referenced in docs"
+fi
+
+# 4) Worktree example from origin/main -b (weak check)
+if ! grep -Rni --include='*.md' 'worktree add .* origin/main -b' . >/dev/null; then
+  err "missing canonical worktree example with 'origin/main -b'"
+fi
+
+$fail && exit 1 || { info "SDD structure lint passed"; exit 0; }
+

--- a/sdd-rules/AGENTS.md
+++ b/sdd-rules/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md (Authoritative)
+
+This document defines the unified development rules for human engineers and AI coding agents (Claude Code, WARP, Gemini, Codex, etc.). It complements CONTRIBUTING.md and sdd-rules/lifecycle.md.
+
+Authority and scope
+- Normative authority:
+  - CONTRIBUTING.md (engineering ground rules)
+  - sdd-rules/lifecycle.md (SDD-driven lifecycle)
+- This file applies to all contributors (human and AI). Agent-specific files (e.g., CLAUDE.md, WARP.md) must align with this file.
+
+Language policy
+- All normative artifacts (PRDs/specs/plans/issues/templates) MUST be in English.
+- Chinese documents are allowed as non-normative references under dev-docs/zh-CN/ with a disclaimer.
+
+Branch and worktree policy
+- Branch categories (canonical): feature | fix | perf | chore | docs (kebab-case)
+- Create a new worktree and branch from origin/main (worktree-first):
+  git -C /Users/arthur/dev-space/ACPLazyBridge worktree add /Users/arthur/dev-space/acplb-worktrees/<task-dir> origin/main -b <branch>
+- Optional IDE navigation:
+  ln -sfn /Users/arthur/dev-space/acplb-worktrees/<task-dir> /Users/arthur/dev-space/ACPLazyBridge/.worktrees/<task-dir>
+
+SDD compliance (must do per task)
+- Create specs/<NNN>-<slug>/:
+  - spec.md (WHAT/WHY; requirements and acceptance)
+  - plan.md (technical plan; architecture and trade-offs)
+  - tasks.md (subtasks; responsibilities; test plan)
+- Metadata block at the top of each file (and mirrored in the GitHub Issue body):
+  - Issue-URI: <link to the GitHub issue>
+  - Spec-URI / Plan-URI / Tasks-URI: <self links>
+  - Evidence-URIs: dev-docs/review/_artifacts/{tests|logs|jq|reports}/<task>/...
+- PR description MUST include links to Spec/Plan/Tasks, evidence (tests/logs/jq/reports), risks/rollback, and CI summary.
+
+Quality gates
+- cargo fmt --all -- --check
+- cargo clippy --workspace --all-targets --all-features -- -D warnings
+- cargo test --workspace --all-features --locked
+- Protocol JSONL scenarios (if present) replay cleanly; stdout is valid JSONL
+- Code scanning via GitHub Code Scanning is enabled; local custom CodeQL queries are allowed (see dev-docs/engineering/codeql.md)
+
+Evidence & traceability
+- Evidence root: dev-docs/review/_artifacts/{tests,logs,jq,reports}/<task>/
+- Maintain traceability files (when used by the task):
+  - dev-docs/review/_artifacts/IMPL.csv (symbol → file:line → mapped IDs)
+  - dev-docs/review/_artifacts/traceability.csv (REQ/ARC ↔ SPEC/CODEX/ZED status)
+
+Protocol discipline (ACP)
+- stdout strictly JSONL; logs to stderr
+- ACP v1 examples MUST use "protocolVersion": 1
+- Use standard JSON-RPC 2.0 error codes; include descriptive messages and optional data
+
+Security
+- Never log secrets; use environment variables and GitHub secrets
+- Avoid running untrusted code or scripts without review
+
+References
+- CONTRIBUTING.md
+- sdd-rules/lifecycle.md
+- sdd-rules/spec-template.md, sdd-rules/plan-template.md, sdd-rules/tasks-template.md
+

--- a/sdd-rules/CLAUDE.md
+++ b/sdd-rules/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md (Authoritative)
+
+This document defines Claude Code–specific rules in ACPLazyBridge. It inherits the global rules from CONTRIBUTING.md and sdd-rules/AGENTS.md.
+
+Authority and scope
+- Normative authority: CONTRIBUTING.md, sdd-rules/lifecycle.md, sdd-rules/AGENTS.md
+- This file provides Claude-specific clarifications and must remain consistent with the above.
+
+Key rules (Claude Code)
+- Worktree-first; branch categories: feature | fix | perf | chore | docs
+- Stdout strictly JSONL; logs to stderr only
+- Evidence stored under dev-docs/review/_artifacts/{tests,logs,jq,reports}/<task>/
+- Non-interactive permission mapping (typical defaults): approval_policy=never; sandbox_mode per task; network access only when explicitly required
+- Protocol examples MUST use ACP v1: "protocolVersion": 1
+
+Submission checklist (Claude PRs)
+- Links to Spec/Plan/Tasks (specs/<NNN>-<slug>/)
+- Evidence links (tests/logs/jq/reports)
+- Risks/rollback section
+- CI summary (fmt/clippy/test/replay)
+
+References
+- CONTRIBUTING.md
+- sdd-rules/AGENTS.md
+- sdd-rules/lifecycle.md
+

--- a/sdd-rules/lifecycle.md
+++ b/sdd-rules/lifecycle.md
@@ -1,0 +1,43 @@
+# Lifecycle (Authoritative)
+
+This lifecycle defines the end-to-end workflow for every task (human or AI engineer).
+
+Nodes and expected artifacts
+1) Requirements analysis
+   - Artifact: specs/<NNN>-<slug>/spec.md (WHAT/WHY; acceptance criteria)
+   - Includes metadata (Issue-URI, Spec-URI, Evidence-URIs)
+
+2) Product/architecture design
+   - Artifact: specs/<NNN>-<slug>/design.md or data-model.md (optional)
+   - May include contracts/diagrams/research
+
+3) Technical plan
+   - Artifact: specs/<NNN>-<slug>/plan.md (approach, components, trade-offs)
+
+4) Issues
+   - Artifact: GitHub Issue with links to Spec/Plan/Tasks/Evidence
+   - Mirrors the metadata block from spec.md
+
+5) Development (worktree-first)
+   - Branch: feature|fix|perf|chore|docs/<kebab-slug>
+   - Worktree from origin/main; follow quality gates
+
+6) Acceptance & submit
+   - Evidence placed under dev-docs/review/_artifacts/{tests,logs,jq,reports}/<task>/
+   - PR description links Spec/Plan/Tasks and evidence; includes risks/rollback and CI summary
+
+7) CI (GitHub Actions + Code Scanning)
+   - Rust gates (fmt/clippy/test)
+   - JSONL replay (if scenarios exist)
+   - SDD structure + language checks
+
+8) PR review & merge
+   - CODEOWNERS review; squash merge into main
+
+9) Task end
+   - Update specs/<NNN>-<slug>/tasks.md status
+   - Close Issue; run drift checks if needed
+
+References
+- CONTRIBUTING.md
+- sdd-rules/spec-template.md, sdd-rules/plan-template.md, sdd-rules/tasks-template.md

--- a/sdd-rules/plan-template.md
+++ b/sdd-rules/plan-template.md
@@ -1,0 +1,24 @@
+# Plan Template
+
+Metadata
+- Issue-URI: <https://github.com/<owner>/<repo>/issues/<id>>
+- Spec-URI: specs/<NNN>-<slug>/spec.md
+- Plan-URI: specs/<NNN>-<slug>/plan.md
+- Tasks-URI: specs/<NNN>-<slug>/tasks.md
+- Evidence-URIs: dev-docs/review/_artifacts/{tests,logs,jq,reports}/<NNN>-<slug>/
+
+1. Architecture & Approach
+- Components, interfaces, data flow
+- Alternatives & trade-offs
+
+2. Risks & Mitigations
+
+3. Testing Strategy
+- Unit/integration/e2e/contract tests; JSONL/jq if applicable
+
+4. Rollout & Migration
+- Feature flags, fallback, rollback
+
+5. References
+- Link to spec/tasks/issue
+

--- a/sdd-rules/spec-driven.md
+++ b/sdd-rules/spec-driven.md
@@ -1,0 +1,17 @@
+# Spec-driven (Authoritative)
+
+Principles
+- Specification-first: WHAT/WHY (spec.md) precedes HOW (plan.md) and execution (tasks.md)
+- Contracts-first where practical; write/agree on validations early (jq checks, JSON schema, contract tests)
+- Single model representation; avoid unnecessary abstraction
+- Integration-first (prefer real dependencies where practical)
+
+Traceability
+- Maintain forward/back links among Spec/Plan/Tasks/Issue
+- Capture evidence under dev-docs/review/_artifacts/{tests,logs,jq,reports}/<task>/ and link into Spec/Plan/Tasks
+
+Templates
+- sdd-rules/spec-template.md
+- sdd-rules/plan-template.md
+- sdd-rules/tasks-template.md
+

--- a/sdd-rules/spec-template.md
+++ b/sdd-rules/spec-template.md
@@ -1,0 +1,27 @@
+# Specification Template
+
+Metadata
+- Issue-URI: <https://github.com/<owner>/<repo>/issues/<id>>
+- Spec-URI: specs/<NNN>-<slug>/spec.md
+- Plan-URI: specs/<NNN>-<slug>/plan.md
+- Tasks-URI: specs/<NNN>-<slug>/tasks.md
+- Evidence-URIs:
+  - dev-docs/review/_artifacts/tests/<NNN>-<slug>/...
+  - dev-docs/review/_artifacts/logs/<NNN>-<slug>/...
+  - dev-docs/review/_artifacts/jq/<NNN>-<slug>/...
+  - dev-docs/review/_artifacts/reports/<NNN>-<slug>/...
+
+1. Overview (WHAT & WHY)
+- Problem statement, goals, non-goals
+
+2. Requirements & Acceptance Criteria
+- Functional, non-functional
+- Clear acceptance tests (linked to JSONL/jq when applicable)
+
+3. Scope & Constraints
+- In-scope / out-of-scope
+- Security/privacy constraints
+
+4. References
+- Link to requirements/design/plan/issue
+

--- a/sdd-rules/tasks-template.md
+++ b/sdd-rules/tasks-template.md
@@ -1,0 +1,24 @@
+# Tasks Template
+
+Metadata
+- Issue-URI: <https://github.com/<owner>/<repo>/issues/<id>>
+- Spec-URI: specs/<NNN>-<slug>/spec.md
+- Plan-URI: specs/<NNN>-<slug>/plan.md
+- Tasks-URI: specs/<NNN>-<slug>/tasks.md
+- Evidence-URIs: dev-docs/review/_artifacts/{tests,logs,jq,reports}/<NNN>-<slug>/
+
+1. Task Breakdown
+- [ ] T1: ... (owner, estimate)
+- [ ] T2: ...
+
+2. Validation Checklist
+- [ ] CI (fmt/clippy/test) green
+- [ ] JSONL scenarios replay (if present)
+- [ ] Evidence files saved under _artifacts
+- [ ] PR description includes Spec/Plan/Tasks/Evidence links and risk/rollback
+
+3. Post-merge
+- [ ] Clean up worktree
+- [ ] Update tasks.md status to Done
+- [ ] Close Issue
+


### PR DESCRIPTION
## Summary\nAlign repository to SDD workflow and authority.\n\n## Key changes\n- Add sdd-rules/ (AGENTS, CLAUDE, lifecycle, spec-driven, templates)\n- Update WARP.md authority + ACP v1 examples + evidence path\n- Unify CLAUDE.md/AGENTS.md examples to protocolVersion: 1\n- Standardize worktree example (origin/main -b) and branch categories (incl. perf)\n- CI: add SDD structure + language checks\n- PR template: add SDD compliance checklist\n- Issue templates: unify evidence path + worktree pattern\n\n## Evidence\n- Local lint: scripts/ci/run-sdd-structure-lint.sh — passed\n- Language policy (sdd-rules/* English-only) — passed\n- Rust gates: fmt/clippy/test — passed\n\n## Links\n- Authority: CONTRIBUTING.md, sdd-rules/lifecycle.md, sdd-rules/AGENTS.md\n- Templates: sdd-rules/spec-template.md, sdd-rules/plan-template.md, sdd-rules/tasks-template.md\n- Evidence root: dev-docs/review/_artifacts/{tests,logs,jq,reports}/\n\n## Risks & Rollback\nLow risk (docs + CI scripts). Single-commit revert possible if needed.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 文档
  - 统一 ACP 协议示例为 protocolVersion: 1
  - 新增参考文档：ACP、Claude Code 适配器、CLI（Claude/Codex/Gemini）、Zed IDE
  - 增补 SDD 索引与生命周期，提供规范化模板（Spec/Plan/Tasks）
  - 重写 WARP 指南；新增 AGENTS/CLAUDE 规范与证据路径调整
  - 计划与问题模板更新：基于 origin/main 的 worktree 流程与证据目录

- 杂务
  - CI 增加 SDD 结构校验与语言策略检查
  - PR 模板更新：分支类别、Spec/Plan/Tasks 链接、证据路径、ACP v1 示例、风险与回滚填写

<!-- end of auto-generated comment: release notes by coderabbit.ai -->