### PR TITLE
docs(rules): sync baseline SDD rules into sdd-rules/rules

### DIFF
--- a/sdd-rules/rules/changelog/sdd-rules-changelog.md
+++ b/sdd-rules/rules/changelog/sdd-rules-changelog.md
@@ -1,0 +1,8 @@
+# SDD Rules - Changelog
+
+- sdd-rules/rules/changelog/keep-a-changelog-index.html.haml
+- sdd-rules/rules/changelog/semver.md
+
+---
+
+specification_version: 1.0.3 | sdd-rules-changelog.md Format: 1.0 | Last Updated: 2025-09-11

--- a/sdd-rules/rules/ci/sdd-rules-ci.md
+++ b/sdd-rules/rules/ci/sdd-rules-ci.md
@@ -1,0 +1,666 @@
+# SDD Rules - CI
+
+[TODO: Add SDD Rules - CI rules]
+
+## Claude Code GitHub Actions
+
+> Learn about integrating Claude Code into your development workflow with Claude Code GitHub Actions
+
+Claude Code GitHub Actions brings AI-powered automation to your GitHub workflow. With a simple `@claude` mention in any PR or issue, Claude can analyze your code, create pull requests, implement features, and fix bugs - all while following your project's standards.
+
+<Note>
+  Claude Code GitHub Actions is built on top of the [Claude Code
+  SDK](/en/docs/claude-code/sdk), which enables programmatic integration of
+  Claude Code into your applications. You can use the SDK to build custom
+  automation workflows beyond GitHub Actions.
+</Note>
+
+### Why use Claude Code GitHub Actions?
+
+* **Instant PR creation**: Describe what you need, and Claude creates a complete PR with all necessary changes
+* **Automated code implementation**: Turn issues into working code with a single command
+* **Follows your standards**: Claude respects your `CLAUDE.md` guidelines and existing code patterns
+* **Simple setup**: Get started in minutes with our installer and API key
+* **Secure by default**: Your code stays on Github's runners
+
+### What can Claude do?
+
+Claude Code provides a powerful GitHub Action that transforms how you work with code:
+
+#### Claude Code Action
+
+This GitHub Action allows you to run Claude Code within your GitHub Actions workflows. You can use this to build any custom workflow on top of Claude Code.
+
+[View repository →](https://github.com/anthropics/claude-code-action)
+
+### Setup
+
+### Quick setup
+
+The easiest way to set up this action is through Claude Code in the terminal. Just open claude and run `/install-github-app`.
+
+This command will guide you through setting up the GitHub app and required secrets.
+
+<Note>
+  * You must be a repository admin to install the GitHub app and add secrets -
+    This quickstart method is only available for direct Anthropic API users. If
+    you're using AWS Bedrock or Google Vertex AI, please see the [Using with AWS
+    Bedrock & Google Vertex AI](#using-with-aws-bedrock-%26-google-vertex-ai)
+    section.
+</Note>
+
+### Manual setup
+
+If the `/install-github-app` command fails or you prefer manual setup, please follow these manual setup instructions:
+
+1. **Install the Claude GitHub app** to your repository: [https://github.com/apps/claude](https://github.com/apps/claude)
+2. **Add ANTHROPIC\_API\_KEY** to your repository secrets ([Learn how to use secrets in GitHub Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions))
+3. **Copy the workflow file** from [examples/claude.yml](https://github.com/anthropics/claude-code-action/blob/main/examples/claude.yml) into your repository's `.github/workflows/`
+
+<Tip>
+  After completing either the quickstart or manual setup, test the action by
+  tagging `@claude` in an issue or PR comment!
+</Tip>
+
+### Upgrading from Beta
+
+<Warning>
+  Claude Code GitHub Actions v1.0 introduces breaking changes that require updating your workflow files in order to upgrade to v1.0 from the beta version.
+</Warning>
+
+If you're currently using the beta version of Claude Code GitHub Actions, we recommend that you update your workflows to use the GA version. The new version simplifies configuration while adding powerful new features like automatic mode detection.
+
+#### Essential changes
+
+All beta users must make these changes to their workflow files in order to upgrade:
+
+1. **Update the action version**: Change `@beta` to `@v1`
+2. **Remove mode configuration**: Delete `mode: "tag"` or `mode: "agent"` (now auto-detected)
+3. **Update prompt inputs**: Replace `direct_prompt` with `prompt`
+4. **Move CLI options**: Convert `max_turns`, `model`, `custom_instructions`, etc. to `claude_args`
+
+#### Breaking Changes Reference
+
+| Old Beta Input        | New v1.0 Input                   |
+| --------------------- | -------------------------------- |
+| `mode`                | *(Removed - auto-detected)*      |
+| `direct_prompt`       | `prompt`                         |
+| `override_prompt`     | `prompt` with GitHub variables   |
+| `custom_instructions` | `claude_args: --system-prompt`   |
+| `max_turns`           | `claude_args: --max-turns`       |
+| `model`               | `claude_args: --model`           |
+| `allowed_tools`       | `claude_args: --allowedTools`    |
+| `disallowed_tools`    | `claude_args: --disallowedTools` |
+| `claude_env`          | `settings` JSON format           |
+
+#### Before and After Example
+
+**Beta version:**
+
+```yaml
+- uses: anthropics/claude-code-action@beta
+  with:
+    mode: "tag"
+    direct_prompt: "Review this PR for security issues"
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    custom_instructions: "Follow our coding standards"
+    max_turns: "10"
+    model: "claude-3-5-sonnet-20241022"
+```
+
+**GA version (v1.0):**
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    prompt: "Review this PR for security issues"
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    claude_args: |
+      --system-prompt "Follow our coding standards"
+      --max-turns 10
+      --model claude-sonnet-4-20250514
+```
+
+<Tip>
+  The action now automatically detects whether to run in interactive mode (responds to `@claude` mentions) or automation mode (runs immediately with a prompt) based on your configuration.
+</Tip>
+
+### Example use cases
+
+Claude Code GitHub Actions can help you with a variety of tasks. The [examples directory](https://github.com/anthropics/claude-code-action/tree/main/examples) contains ready-to-use workflows for different scenarios.
+
+#### Basic workflow
+
+```yaml
+name: Claude Code
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Responds to @claude mentions in comments
+```
+
+#### Using slash commands
+
+```yaml
+name: Code Review
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "/review"
+          claude_args: "--max-turns 5"
+```
+
+#### Custom automation with prompts
+
+```yaml
+name: Daily Report
+on:
+  schedule:
+    - cron: "0 9 * * *"
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "Generate a summary of yesterday's commits and open issues"
+          claude_args: "--model claude-opus-4-1-20250805"
+```
+
+#### Common use cases
+
+In issue or PR comments:
+
+```
+@claude implement this feature based on the issue description
+@claude how should I implement user authentication for this endpoint?
+@claude fix the TypeError in the user dashboard component
+```
+
+Claude will automatically analyze the context and respond appropriately.
+
+### Best practices
+
+#### CLAUDE.md configuration
+
+Create a `CLAUDE.md` file in your repository root to define code style guidelines, review criteria, project-specific rules, and preferred patterns. This file guides Claude's understanding of your project standards.
+
+#### Security considerations
+
+<Warning>Never commit API keys directly to your repository!</Warning>
+
+Always use GitHub Secrets for API keys:
+
+* Add your API key as a repository secret named `ANTHROPIC_API_KEY`
+* Reference it in workflows: `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`
+* Limit action permissions to only what's necessary
+* Review Claude's suggestions before merging
+
+Always use GitHub Secrets (e.g., `${{ secrets.ANTHROPIC_API_KEY }}`) rather than hardcoding API keys directly in your workflow files.
+
+#### Optimizing performance
+
+Use issue templates to provide context, keep your `CLAUDE.md` concise and focused, and configure appropriate timeouts for your workflows.
+
+#### CI costs
+
+When using Claude Code GitHub Actions, be aware of the associated costs:
+
+**GitHub Actions costs:**
+
+* Claude Code runs on GitHub-hosted runners, which consume your GitHub Actions minutes
+* See [GitHub's billing documentation](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions) for detailed pricing and minute limits
+
+**API costs:**
+
+* Each Claude interaction consumes API tokens based on the length of prompts and responses
+* Token usage varies by task complexity and codebase size
+* See [Claude's pricing page](https://www.anthropic.com/api) for current token rates
+
+**Cost optimization tips:**
+
+* Use specific `@claude` commands to reduce unnecessary API calls
+* Configure appropriate `--max-turns` in `claude_args` to prevent excessive iterations
+* Set workflow-level timeouts to avoid runaway jobs
+* Consider using GitHub's concurrency controls to limit parallel runs
+
+### Configuration examples
+
+The Claude Code Action v1 simplifies configuration with unified parameters:
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    prompt: "Your instructions here" # Optional
+    claude_args: "--max-turns 5" # Optional CLI arguments
+```
+
+Key features:
+
+* **Unified prompt interface** - Use `prompt` for all instructions
+* **Slash commands** - Pre-built prompts like `/review` or `/fix`
+* **CLI passthrough** - Any Claude Code CLI argument via `claude_args`
+* **Flexible triggers** - Works with any GitHub event
+
+Visit the [examples directory](https://github.com/anthropics/claude-code-action/tree/main/examples) for complete workflow files.
+
+<Tip>
+  When responding to issue or PR comments, Claude automatically responds to @claude mentions. For other events, use the `prompt` parameter to provide instructions.
+</Tip>
+
+### Using with AWS Bedrock & Google Vertex AI
+
+For enterprise environments, you can use Claude Code GitHub Actions with your own cloud infrastructure. This approach gives you control over data residency and billing while maintaining the same functionality.
+
+#### Prerequisites
+
+Before setting up Claude Code GitHub Actions with cloud providers, you need:
+
+##### For Google Cloud Vertex AI:
+
+1. A Google Cloud Project with Vertex AI enabled
+2. Workload Identity Federation configured for GitHub Actions
+3. A service account with the required permissions
+4. A GitHub App (recommended) or use the default GITHUB\_TOKEN
+
+##### For AWS Bedrock:
+
+1. An AWS account with Amazon Bedrock enabled
+2. GitHub OIDC Identity Provider configured in AWS
+3. An IAM role with Bedrock permissions
+4. A GitHub App (recommended) or use the default GITHUB\_TOKEN
+
+<Steps>
+  <Step title="Create a custom GitHub App (Recommended for 3P Providers)">
+    For best control and security when using 3P providers like Vertex AI or Bedrock, we recommend creating your own GitHub App:
+
+    1. Go to [https://github.com/settings/apps/new](https://github.com/settings/apps/new)
+    2. Fill in the basic information:
+       * **GitHub App name**: Choose a unique name (e.g., "YourOrg Claude Assistant")
+       * **Homepage URL**: Your organization's website or the repository URL
+    3. Configure the app settings:
+       * **Webhooks**: Uncheck "Active" (not needed for this integration)
+    4. Set the required permissions:
+       * **Repository permissions**:
+         * Contents: Read & Write
+         * Issues: Read & Write
+         * Pull requests: Read & Write
+    5. Click "Create GitHub App"
+    6. After creation, click "Generate a private key" and save the downloaded `.pem` file
+    7. Note your App ID from the app settings page
+    8. Install the app to your repository:
+       * From your app's settings page, click "Install App" in the left sidebar
+       * Select your account or organization
+       * Choose "Only select repositories" and select the specific repository
+       * Click "Install"
+    9. Add the private key as a secret to your repository:
+       * Go to your repository's Settings → Secrets and variables → Actions
+       * Create a new secret named `APP_PRIVATE_KEY` with the contents of the `.pem` file
+    10. Add the App ID as a secret:
+
+    * Create a new secret named `APP_ID` with your GitHub App's ID
+
+    <Note>
+      This app will be used with the [actions/create-github-app-token](https://github.com/actions/create-github-app-token) action to generate authentication tokens in your workflows.
+    </Note>
+
+    **Alternative for Anthropic API or if you don't want to setup your own Github app**: Use the official Anthropic app:
+
+    1. Install from: [https://github.com/apps/claude](https://github.com/apps/claude)
+    2. No additional configuration needed for authentication
+  </Step>
+
+  <Step title="Configure cloud provider authentication">
+    Choose your cloud provider and set up secure authentication:
+
+    <AccordionGroup>
+      <Accordion title="AWS Bedrock">
+        **Configure AWS to allow GitHub Actions to authenticate securely without storing credentials.**
+
+        > **Security Note**: Use repository-specific configurations and grant only the minimum required permissions.
+
+        **Required Setup**:
+
+        1. **Enable Amazon Bedrock**:
+           * Request access to Claude models in Amazon Bedrock
+           * For cross-region models, request access in all required regions
+
+        2. **Set up GitHub OIDC Identity Provider**:
+           * Provider URL: `https://token.actions.githubusercontent.com`
+           * Audience: `sts.amazonaws.com`
+
+        3. **Create IAM Role for GitHub Actions**:
+           * Trusted entity type: Web identity
+           * Identity provider: `token.actions.githubusercontent.com`
+           * Permissions: `AmazonBedrockFullAccess` policy
+           * Configure trust policy for your specific repository
+
+        **Required Values**:
+
+        After setup, you'll need:
+
+        * **AWS\_ROLE\_TO\_ASSUME**: The ARN of the IAM role you created
+
+        <Tip>
+          OIDC is more secure than using static AWS access keys because credentials are temporary and automatically rotated.
+        </Tip>
+
+        See [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html) for detailed OIDC setup instructions.
+      </Accordion>
+
+      <Accordion title="Google Vertex AI">
+        **Configure Google Cloud to allow GitHub Actions to authenticate securely without storing credentials.**
+
+        > **Security Note**: Use repository-specific configurations and grant only the minimum required permissions.
+
+        **Required Setup**:
+
+        1. **Enable APIs** in your Google Cloud project:
+           * IAM Credentials API
+           * Security Token Service (STS) API
+           * Vertex AI API
+
+        2. **Create Workload Identity Federation resources**:
+           * Create a Workload Identity Pool
+           * Add a GitHub OIDC provider with:
+             * Issuer: `https://token.actions.githubusercontent.com`
+             * Attribute mappings for repository and owner
+             * **Security recommendation**: Use repository-specific attribute conditions
+
+        3. **Create a Service Account**:
+           * Grant only `Vertex AI User` role
+           * **Security recommendation**: Create a dedicated service account per repository
+
+        4. **Configure IAM bindings**:
+           * Allow the Workload Identity Pool to impersonate the service account
+           * **Security recommendation**: Use repository-specific principal sets
+
+        **Required Values**:
+
+        After setup, you'll need:
+
+        * **GCP\_WORKLOAD\_IDENTITY\_PROVIDER**: The full provider resource name
+        * **GCP\_SERVICE\_ACCOUNT**: The service account email address
+
+        <Tip>
+          Workload Identity Federation eliminates the need for downloadable service account keys, improving security.
+        </Tip>
+
+        For detailed setup instructions, consult the [Google Cloud Workload Identity Federation documentation](https://cloud.google.com/iam/docs/workload-identity-federation).
+      </Accordion>
+    </AccordionGroup>
+  </Step>
+
+  <Step title="Add Required Secrets">
+    Add the following secrets to your repository (Settings → Secrets and variables → Actions):
+
+    ##### For Anthropic API (Direct):
+
+    1. **For API Authentication**:
+       * `ANTHROPIC_API_KEY`: Your Anthropic API key from [console.anthropic.com](https://console.anthropic.com)
+
+    2. **For GitHub App (if using your own app)**:
+       * `APP_ID`: Your GitHub App's ID
+       * `APP_PRIVATE_KEY`: The private key (.pem) content
+
+    ##### For Google Cloud Vertex AI
+
+    1. **For GCP Authentication**:
+       * `GCP_WORKLOAD_IDENTITY_PROVIDER`
+       * `GCP_SERVICE_ACCOUNT`
+
+    2. **For GitHub App (if using your own app)**:
+       * `APP_ID`: Your GitHub App's ID
+       * `APP_PRIVATE_KEY`: The private key (.pem) content
+
+    ##### For AWS Bedrock
+
+    1. **For AWS Authentication**:
+       * `AWS_ROLE_TO_ASSUME`
+
+    2. **For GitHub App (if using your own app)**:
+       * `APP_ID`: Your GitHub App's ID
+       * `APP_PRIVATE_KEY`: The private key (.pem) content
+  </Step>
+
+  <Step title="Create workflow files">
+    Create GitHub Actions workflow files that integrate with your cloud provider. The examples below show complete configurations for both AWS Bedrock and Google Vertex AI:
+
+    <AccordionGroup>
+      <Accordion title="AWS Bedrock workflow">
+        **Prerequisites:**
+
+        * AWS Bedrock access enabled with Claude model permissions
+        * GitHub configured as an OIDC identity provider in AWS
+        * IAM role with Bedrock permissions that trusts GitHub Actions
+
+        **Required GitHub secrets:**
+
+        | Secret Name          | Description                                       |
+        | -------------------- | ------------------------------------------------- |
+        | `AWS_ROLE_TO_ASSUME` | ARN of the IAM role for Bedrock access            |
+        | `APP_ID`             | Your GitHub App ID (from app settings)            |
+        | `APP_PRIVATE_KEY`    | The private key you generated for your GitHub App |
+
+        ```yaml
+        name: Claude PR Action
+
+        permissions:
+          contents: write
+          pull-requests: write
+          issues: write
+          id-token: write
+
+        on:
+          issue_comment:
+            types: [created]
+          pull_request_review_comment:
+            types: [created]
+          issues:
+            types: [opened, assigned]
+
+        jobs:
+          claude-pr:
+            if: |
+              (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+              (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+              (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+            runs-on: ubuntu-latest
+            env:
+              AWS_REGION: us-west-2
+            steps:
+              - name: Checkout repository
+                uses: actions/checkout@v4
+
+              - name: Generate GitHub App token
+                id: app-token
+                uses: actions/create-github-app-token@v2
+                with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+              - name: Configure AWS Credentials (OIDC)
+                uses: aws-actions/configure-aws-credentials@v4
+                with:
+                  role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+                  aws-region: us-west-2
+
+              - uses: anthropics/claude-code-action@v1
+                with:
+                  github_token: ${{ steps.app-token.outputs.token }}
+                  use_bedrock: "true"
+                  claude_args: '--model us.anthropic.claude-sonnet-4-20250514-v1:0 --max-turns 10'
+        ```
+
+        <Tip>
+          The model ID format for Bedrock includes the region prefix (e.g., `us.anthropic.claude...`) and version suffix.
+        </Tip>
+      </Accordion>
+
+      <Accordion title="Google Vertex AI workflow">
+        **Prerequisites:**
+
+        * Vertex AI API enabled in your GCP project
+        * Workload Identity Federation configured for GitHub
+        * Service account with Vertex AI permissions
+
+        **Required GitHub secrets:**
+
+        | Secret Name                      | Description                                       |
+        | -------------------------------- | ------------------------------------------------- |
+        | `GCP_WORKLOAD_IDENTITY_PROVIDER` | Workload identity provider resource name          |
+        | `GCP_SERVICE_ACCOUNT`            | Service account email with Vertex AI access       |
+        | `APP_ID`                         | Your GitHub App ID (from app settings)            |
+        | `APP_PRIVATE_KEY`                | The private key you generated for your GitHub App |
+
+        ```yaml
+        name: Claude PR Action
+
+        permissions:
+          contents: write
+          pull-requests: write
+          issues: write
+          id-token: write
+
+        on:
+          issue_comment:
+            types: [created]
+          pull_request_review_comment:
+            types: [created]
+          issues:
+            types: [opened, assigned]
+
+        jobs:
+          claude-pr:
+            if: |
+              (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+              (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+              (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+            runs-on: ubuntu-latest
+            steps:
+              - name: Checkout repository
+                uses: actions/checkout@v4
+
+              - name: Generate GitHub App token
+                id: app-token
+                uses: actions/create-github-app-token@v2
+                with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+              - name: Authenticate to Google Cloud
+                id: auth
+                uses: google-github-actions/auth@v2
+                with:
+                  workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+                  service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+              - uses: anthropics/claude-code-action@v1
+                with:
+                  github_token: ${{ steps.app-token.outputs.token }}
+                  trigger_phrase: "@claude"
+                  use_vertex: "true"
+                  claude_args: '--model claude-sonnet-4@20250514 --max-turns 10'
+                env:
+                  ANTHROPIC_VERTEX_PROJECT_ID: ${{ steps.auth.outputs.project_id }}
+                  CLOUD_ML_REGION: us-east5
+                  VERTEX_REGION_CLAUDE_3_7_SONNET: us-east5
+        ```
+
+        <Tip>
+          The project ID is automatically retrieved from the Google Cloud authentication step, so you don't need to hardcode it.
+        </Tip>
+      </Accordion>
+    </AccordionGroup>
+  </Step>
+</Steps>
+
+### Troubleshooting
+
+#### Claude not responding to @claude commands
+
+Verify the GitHub App is installed correctly, check that workflows are enabled, ensure API key is set in repository secrets, and confirm the comment contains `@claude` (not `/claude`).
+
+#### CI not running on Claude's commits
+
+Ensure you're using the GitHub App or custom app (not Actions user), check workflow triggers include the necessary events, and verify app permissions include CI triggers.
+
+#### Authentication errors
+
+Confirm API key is valid and has sufficient permissions. For Bedrock/Vertex, check credentials configuration and ensure secrets are named correctly in workflows.
+
+### Advanced configuration
+
+#### Action parameters
+
+The Claude Code Action v1 uses a simplified configuration:
+
+| Parameter           | Description                                     | Required |
+| ------------------- | ----------------------------------------------- | -------- |
+| `prompt`            | Instructions for Claude (text or slash command) | No\*     |
+| `claude_args`       | CLI arguments passed to Claude Code             | No       |
+| `anthropic_api_key` | Anthropic API key                               | Yes\*\*  |
+| `github_token`      | GitHub token for API access                     | No       |
+| `trigger_phrase`    | Custom trigger phrase (default: "@claude")      | No       |
+| `use_bedrock`       | Use AWS Bedrock instead of Anthropic API        | No       |
+| `use_vertex`        | Use Google Vertex AI instead of Anthropic API   | No       |
+
+\*Prompt is optional - when omitted for issue/PR comments, Claude responds to trigger phrase\
+\*\*Required for direct Anthropic API, not for Bedrock/Vertex
+
+##### Using claude\_args
+
+The `claude_args` parameter accepts any Claude Code CLI arguments:
+
+```yaml
+claude_args: "--max-turns 5 --model claude-sonnet-4-20250514 --mcp-config /path/to/config.json"
+```
+
+Common arguments:
+
+* `--max-turns`: Maximum conversation turns (default: 10)
+* `--model`: Model to use (e.g., `claude-sonnet-4-20250514`)
+* `--mcp-config`: Path to MCP configuration
+* `--allowed-tools`: Comma-separated list of allowed tools
+* `--debug`: Enable debug output
+
+#### Alternative integration methods
+
+While the `/install-github-app` command is the recommended approach, you can also:
+
+* **Custom GitHub App**: For organizations needing branded usernames or custom authentication flows. Create your own GitHub App with required permissions (contents, issues, pull requests) and use the actions/create-github-app-token action to generate tokens in your workflows.
+* **Manual GitHub Actions**: Direct workflow configuration for maximum flexibility
+* **MCP Configuration**: Dynamic loading of Model Context Protocol servers
+
+See the [Claude Code Action repository](https://github.com/anthropics/claude-code-action) for detailed documentation.
+
+#### Customizing Claude's behavior
+
+You can configure Claude's behavior in two ways:
+
+1. **CLAUDE.md**: Define coding standards, review criteria, and project-specific rules in a `CLAUDE.md` file at the root of your repository. Claude will follow these guidelines when creating PRs and responding to requests. Check out our [Memory documentation](/en/docs/claude-code/memory) for more details.
+2. **Custom prompts**: Use the `prompt` parameter in the workflow file to provide workflow-specific instructions. This allows you to customize Claude's behavior for different workflows or tasks.
+
+Claude will follow these guidelines when creating PRs and responding to requests.
+
+---
+
+specification_version: 1.0.3 | sdd-rules-ci.md Format: 1.0 | Last Updated: 2025-09-11

--- a/sdd-rules/rules/code-analysis/sdd-rules-code-analysis.md
+++ b/sdd-rules/rules/code-analysis/sdd-rules-code-analysis.md
@@ -1,0 +1,7 @@
+# SDD Rules - Code Analysis
+
+[TODO: Add code analysis rules]
+
+---
+
+specification_version: 1.0.3 | sdd-rules-code-analysis.md Format: 1.0 | Last Updated: 2025-09-11

--- a/sdd-rules/rules/documentation-style/sdd-rules-documentation-style.md
+++ b/sdd-rules/rules/documentation-style/sdd-rules-documentation-style.md
@@ -1,0 +1,20 @@
+# SDD Documentation Style
+
+SDD Documentation Style follows the [Google developer documentation style guide](https://developers.google.com/style).
+
+## Text Style
+
+- Use an imperative style. "Run a prompt using the API."
+- Use sentence case in titles/headings.
+- Use short titles/headings: "Download the data", "Call the API", "Process the results".
+- Use the [Google developer documentation style guide](https://developers.google.com/style).
+- Use second person: "you" rather than "we".
+- When using links between notebooks, use relative ones as they'll work better in IDEs and Colab. Use absolute ones to link to folders or markdown files.
+
+## Markdown - markdownlint configuration
+
+[TODO: Add markdownlint configuration]
+
+---
+
+specification_version: 1.0.3 | sdd-rules-documentation-style.md Format: 1.0 | Last Updated: 2025-09-11

--- a/sdd-rules/rules/git/comments/sdd-rules-comments.md
+++ b/sdd-rules/rules/git/comments/sdd-rules-comments.md
@@ -1,0 +1,7 @@
+# SDD Rules - Git Comments
+
+[TODO: Add git comments rules]
+
+---
+
+specification_version: 1.0.3 | sdd-rules-comments.md Format: 1.0 | Last Updated: 2025-09-11

--- a/sdd-rules/rules/git/issues/sdd-rules-issues.md
+++ b/sdd-rules/rules/git/issues/sdd-rules-issues.md
@@ -1,0 +1,7 @@
+# SDD Rules - Git Issues
+
+[TODO: Add git issues rules]
+
+---
+
+specification_version: 1.0.3 | sdd-rules-issues.md Format: 1.0 | Last Updated: 2025-09-11

--- a/sdd-rules/rules/git/pr/sdd-rules-pr.md
+++ b/sdd-rules/rules/git/pr/sdd-rules-pr.md
@@ -1,0 +1,7 @@
+# SDD Rules - Git PR
+
+[TODO: Add git PR rules]
+
+---
+
+specification_version: 1.0.3 | sdd-rules-pr.md Format: 1.0 | Last Updated: 2025-09-11

--- a/sdd-rules/rules/git/worktree/sdd-rules-worktrees.md
+++ b/sdd-rules/rules/git/worktree/sdd-rules-worktrees.md
@@ -1,0 +1,399 @@
+# Git Worktrees for Parallel Development
+
+Git worktrees enable multiple working directories from a single repository, allowing human and AI engineers to work on different features simultaneously without workspace conflicts.
+
+## Overview
+
+Worktrees provide isolated development environments where each feature, bug fix, or experiment has its own:
+
+- Working directory
+- Branch checkout
+- File state
+- Agent session
+- Dependencies (when initialized)
+
+## Basic Commands
+
+### Creating Worktrees
+
+```bash
+# Create new worktree with new branch
+git worktree add ../spec-kit-feature-auth -b 001-auth
+
+# Create worktree from existing branch
+git worktree add ../spec-kit-bugfix bugfix/security-patch
+
+# Create worktree at specific commit
+git worktree add ../spec-kit-experiment HEAD~3
+```
+
+### Managing Worktrees
+
+```bash
+# List all worktrees
+git worktree list
+
+# Show detailed worktree information
+git worktree list --verbose
+
+# Remove worktree (clean)
+git worktree remove ../spec-kit-feature-auth
+
+# Remove worktree (force)
+git worktree remove --force ../spec-kit-broken
+
+# Prune stale worktree information
+git worktree prune
+```
+
+### Moving Worktrees
+
+```bash
+# Move worktree to new location
+git worktree move ../spec-kit-old ../spec-kit-new
+
+# Repair worktree references after move
+git worktree repair
+```
+
+## Naming Conventions
+
+### Directory Names
+
+Pattern: ../spec-kit-<type>-<id>-<description>
+
+Types:
+
+- feature: New functionality
+- bugfix: Bug repairs  
+- hotfix: Emergency fixes
+- experiment: Exploratory work
+- review: PR reviews
+- release: Release preparation
+
+### Examples
+
+```bash
+../spec-kit-feature-001-auth         # Feature: authentication
+../spec-kit-bugfix-002-validation    # Bug fix: validation error
+../spec-kit-hotfix-003-security      # Hotfix: security patch
+../spec-kit-experiment-ml-pipeline   # Experiment: ML pipeline
+../spec-kit-review-pr-123           # Review: PR #123
+../spec-kit-release-v1.2.0          # Release: version 1.2.0
+```
+
+## SDD Task Workflow
+
+### 1. Create Task Worktree
+
+```bash
+# From main repository
+cd ~/projects/spec-kit
+
+# Create worktree for new task
+git worktree add ../spec-kit-task-001-api origin/main -b task/001-api
+
+# Navigate to worktree
+cd ../spec-kit-task-001-api
+```
+
+### 2. Initialize Environment
+
+```bash
+# Python project
+python -m venv venv
+source venv/bin/activate
+pip install -e .
+
+# Node project
+npm install
+
+# Go project
+go mod download
+```
+
+### 3. Start Agent Session
+
+```bash
+# Claude Code
+code .  # Opens in VS Code with Claude
+
+# Warp Agent
+warp-preview agent run --profile dev \
+  -C . \
+  --prompt "Implement task 001 from spec"
+```
+
+### 4. Development Cycle
+
+```bash
+# Regular git operations work normally
+git add .
+git commit -m "feat: implement API endpoints [TASK-001]"
+git push -u origin task/001-api
+```
+
+### 5. Clean Up
+
+```bash
+# After PR merged
+cd ~/projects/spec-kit
+git worktree remove ../spec-kit-task-001-api
+```
+
+## Parallel Human/AI Tasking
+
+### Scenario: Multiple Features
+
+```bash
+# Human works on frontend
+git worktree add ../spec-kit-frontend origin/main -b feature/ui
+cd ../spec-kit-frontend
+# Human develops...
+
+# AI Agent 1 works on API
+git worktree add ../spec-kit-api origin/main -b feature/api
+cd ../spec-kit-api
+claude-code implement specs/002-api/
+
+# AI Agent 2 works on database
+git worktree add ../spec-kit-database origin/main -b feature/db
+cd ../spec-kit-database
+warp-preview agent run --prompt "Implement database schema"
+
+# AI Agent 3 runs tests
+git worktree add ../spec-kit-testing origin/main -b feature/tests
+cd ../spec-kit-testing
+cursor-agent write tests/
+```
+
+### Coordination
+
+```bash
+# Check all active work
+git worktree list
+# /Users/dev/spec-kit         abc123 [main]
+# /Users/dev/spec-kit-frontend def456 [feature/ui]
+# /Users/dev/spec-kit-api      ghi789 [feature/api]
+# /Users/dev/spec-kit-database jkl012 [feature/db]
+# /Users/dev/spec-kit-testing  mno345 [feature/tests]
+
+# Merge completed work
+cd ~/projects/spec-kit
+git merge feature/api
+git merge feature/db
+```
+
+## Safety Guidelines
+
+### Dependency Isolation
+
+```bash
+# Each worktree needs its own dependencies
+# Bad: Sharing virtual environment
+../spec-kit/venv/
+
+# Good: Separate environments
+../spec-kit/venv/
+../spec-kit-feature/venv/
+../spec-kit-bugfix/venv/
+```
+
+### State Management
+
+```bash
+# Check worktree state before removal
+cd ../spec-kit-feature
+git status  # Ensure no uncommitted changes
+git stash   # Save work if needed
+```
+
+### Branch Protection
+
+```bash
+# Avoid same branch in multiple worktrees
+# This will fail:
+git worktree add ../spec-kit-dup -b main  # Error: branch already checked out
+
+# Use different branches
+git worktree add ../spec-kit-exp -b experiment/test
+```
+
+## Agent Integration
+
+### Claude Code
+
+```bash
+# Each worktree gets its own Claude session
+cd ../spec-kit-feature-auth
+code .  # New VS Code window with Claude
+
+# Claude uses worktree's git context
+# Branch: feature/001-auth
+# No interference with other worktrees
+```
+
+### Warp Agent
+
+```bash
+# Specify worktree path
+warp-preview agent run \
+  -C ../spec-kit-bugfix \
+  --profile dev \
+  --prompt "Fix validation bug"
+```
+
+### Multiple Agents
+
+```bash
+# Agent 1 in worktree 1
+cd ../spec-kit-task-001
+claude-code implement
+
+# Agent 2 in worktree 2  
+cd ../spec-kit-task-002
+warp-preview agent run
+
+# No conflicts or confusion
+```
+
+## Best Practices
+
+### Do's
+
+- Create worktree per task/feature
+- Initialize dependencies separately
+- Use descriptive worktree names
+- Clean up completed worktrees
+- Keep main branch in primary repo
+
+### Don'ts
+
+- Share worktrees between agents
+- Leave stale worktrees
+- Commit from wrong worktree
+- Force remove with uncommitted changes
+- Create deeply nested worktrees
+
+## Troubleshooting
+
+### Worktree Locked
+
+```bash
+# If worktree is locked
+git worktree unlock ../spec-kit-feature
+
+# Force unlock if needed
+rm ../spec-kit-feature/.git/worktree.lock
+```
+
+### Missing Worktree
+
+```bash
+# If directory was deleted
+git worktree prune
+
+# Repair references
+git worktree repair
+```
+
+### Branch Conflicts
+
+```bash
+# Check what's using branch
+git worktree list | grep feature/auth
+
+# Remove conflicting worktree
+git worktree remove ../old-worktree
+```
+
+## Example Workflows
+
+### Feature Development
+
+```bash
+#!/bin/bash
+# create-feature-worktree.sh
+
+FEATURE_NAME=$1
+FEATURE_BRANCH="feature/$FEATURE_NAME"
+WORKTREE_DIR="../spec-kit-$FEATURE_NAME"
+
+# Create worktree
+git worktree add "$WORKTREE_DIR" -b "$FEATURE_BRANCH"
+
+# Setup environment
+cd "$WORKTREE_DIR"
+python -m venv venv
+source venv/bin/activate
+pip install -e .
+
+# Start development
+code .
+```
+
+### Parallel Testing
+
+```bash
+#!/bin/bash  
+# parallel-test.sh
+
+# Create test worktrees
+git worktree add ../spec-kit-test-unit HEAD
+git worktree add ../spec-kit-test-integration HEAD
+git worktree add ../spec-kit-test-e2e HEAD
+
+# Run tests in parallel
+(cd ../spec-kit-test-unit && pytest tests/unit/) &
+(cd ../spec-kit-test-integration && pytest tests/integration/) &
+(cd ../spec-kit-test-e2e && pytest tests/e2e/) &
+
+# Wait for completion
+wait
+```
+
+### Review Workflow
+
+```bash
+#!/bin/bash
+# review-pr.sh
+
+PR_NUMBER=$1
+WORKTREE_DIR="../spec-kit-review-pr-$PR_NUMBER"
+
+# Fetch PR branch
+gh pr checkout $PR_NUMBER --detach
+
+# Create review worktree
+git worktree add "$WORKTREE_DIR" HEAD
+
+# Run review
+cd "$WORKTREE_DIR"
+warp-preview agent run --profile review \
+  --prompt "Review changes for SDD compliance"
+```
+
+## Performance Considerations
+
+### Disk Usage
+
+- Each worktree has full working directory
+- Shared .git repository saves space
+- Consider SSD for better performance
+- Clean up unused worktrees regularly
+
+### Memory Usage
+
+- Each agent session uses separate memory
+- Dependencies loaded per worktree
+- Monitor system resources with many worktrees
+
+### Network
+
+- Parallel pushes may hit rate limits
+- Coordinate push timing if needed
+- Use different remotes if necessary
+
+---
+
+specification_version: 1.0.3 | sdd-rules-worktrees.md Format: 1.0 | Last Updated: 2025-09-11

--- a/sdd-rules/rules/resaerch/sdd-rules-resaerch.md
+++ b/sdd-rules/rules/resaerch/sdd-rules-resaerch.md
@@ -1,0 +1,7 @@
+# SDD Rules - Research
+
+[TODO: Add research rules]
+
+---
+
+specification_version: 1.0.3 | sdd-rules-research.md Format: 1.0 | Last Updated: 2025-09-11

--- a/sdd-rules/rules/tests/sdd-rules-tests.md
+++ b/sdd-rules/rules/tests/sdd-rules-tests.md
@@ -1,0 +1,7 @@
+# SDD Rules - Tests
+
+[TODO: Add tests rules]
+
+---
+
+specification_version: 1.0.3 | sdd-rules-tests.md Format: 1.0 | Last Updated: 2025-09-11

--- a/sdd-rules/rules/tools-mcp/sdd-rules-tools-mcp.md
+++ b/sdd-rules/rules/tools-mcp/sdd-rules-tools-mcp.md
@@ -1,0 +1,155 @@
+# SDD Rules - Tools MCP
+
+## MCP Servers Configuration
+
+```bash
+# MCP Servers Authorization Token
+export GITHUB_TOKEN=$(security find-generic-password -s github)
+export JINA_API_KEY=$(security find-generic-password -s jina)
+export ANTHROPIC_API_KEY=$(security find-generic-password -s anthropic)
+```
+
+### "github-mcp"
+
+- [MCP] <https://github.com/github/github-mcp-server>
+
+**Purpose**: Repository operations
+**install**: remote HTTP server
+**Agents**: All
+**Config**:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+**For Claude Code CLI:**
+
+```bash
+claude mcp add --transport http github https://api.githubcopilot.com/mcp -H "Authorization: Bearer YOUR_GITHUB_PAT"
+```
+
+### "jina-mcp"
+
+- [MCP] <https://github.com/jina-ai/MCP>
+
+**Purpose**: Web research and extraction
+**install**: remote HTTP server
+**Agents**: All
+**Config**:
+
+```json
+{
+  "mcpServers": {
+    "jina-mcp-server": {
+      "url": "https://mcp.jina.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer ${JINA_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+**For Claude Code CLI:**
+
+```bash
+claude mcp add --transport sse jina-mcp https://mcp.jina.ai/sse \
+  --header "X-API-Key: Bearer ${JINA_API_KEY}"
+```
+
+### "context7"
+
+- [MCP] <https://github.com/upstash/context7>
+
+**Purpose**: Library documentation
+**install**: remote HTTP server
+**Agents**: All
+**Config**:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "{CONTEXT7_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+**For Claude Code CLI:**
+
+```bash
+claude mcp add --transport http context7 https://mcp.context7.com/mcp --header "CONTEXT7_API_KEY: YOUR_API_KEY"
+```
+
+### "deepwiki"
+
+- [MCP] <https://mcp.deepwiki.com>
+
+**Purpose**: any Github Repository research
+**install**: remote HTTP server
+**Agents**: All
+**Config**:
+
+```json
+{
+  "mcpServers": {
+    "deepwiki": {
+      "serverUrl": "https://mcp.deepwiki.com/mcp"
+    }
+  }
+}
+```
+
+**For Claude Code CLI:**
+
+```bash
+claude mcp add -s user -t http deepwiki https://mcp.deepwiki.com/mcp
+```
+
+### "serena"
+
+- [MCP] <https://github.com/oraios/serena>
+
+**Purpose**: Semantic code analysis
+**install**: local stdio macp server
+
+```bash
+uvx --from git+https://github.com/oraios/serena serena start-mcp-server
+```
+
+**Agents**: All
+**Config**:
+
+```json
+{
+    "mcpServers": {
+        "serena": {
+            "command": "/abs/path/to/uvx",
+            "args": ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server"]
+        }
+    }
+}
+```
+
+**For Claude Code CLI:**
+
+```bash
+claude mcp add serena -- uvx --from git+https://github.com/oraios/serena serena start-mcp-server --context ide-assistant --project $(pwd)
+```
+
+---
+
+specification_version: 1.0.3 | sdd-rules-tools-mcp.md Format: 1.0 | Last Updated: 2025-09-11


### PR DESCRIPTION
Sync Developer Team AI Engineers SDD rules baseline from external sdd-rules-base into repo under sdd-rules/rules.\n- Non-destructive merge copy (no delete)\n- Worktree-first branch: docs/sync-sdd-rules-base-20250911\n\nChecked: no outdated protocolVersion date-string in synced docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 文档
  * 新增多篇 SDD 规则文档：变更日志、代码分析、文档风格、Research/Tests 框架。
  * Git 指南：Comments/Issues/PR 基础框架与 Worktree 实践与示例。
  * CI 指南：面向 GitHub Actions 的集成、配置、最佳实践与故障排查。
  * 工具集成：MCP 服务器配置与示例，涵盖多云与本地场景。
  * 所有文档含版本与更新时间标注，便于追踪与维护。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->