### PR TITLE
docs: CLAUDE & rules links, memory layering, per-dir CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,24 @@
-# CLAUDE.md (AGENTS.md)
+# CLAUDE.md (Repository-level Claude Code Guide)
+
+Authority and scope
+- Normative authority: CONTRIBUTING.md, sdd-rules/CLAUDE.md, sdd-rules/AGENTS.md, sdd-rules/lifecycle.md
+- Rules index: sdd-rules/rules/README.md
+- This file provides repository-level guidance for Claude Code; it must align with the authoritative files above.
+
+SDD navigation (three-horse synergy)
+- Scripts: scripts/ (ci/sdd/common/utilities)
+- Specs: specs/<NNN>-<slug>/(spec.md, plan.md, tasks.md)
+- Dev-docs & Issues & Review: dev-docs/requirements, dev-docs/design, dev-docs/plan/issues, dev-docs/review/changes, dev-docs/review/_artifacts, GitHub Issues (with comments)
+- Templates: sdd-rules/spec-template.md, sdd-rules/plan-template.md, sdd-rules/tasks-template.md
+- Commands: sdd-rules/commands/specify.md, sdd-rules/commands/plan.md, sdd-rules/commands/tasks.md
+
+Memory layering (Claude Code)
+- Root CLAUDE.md (this file): global repository guidance and SDD navigation
+- sdd-rules/CLAUDE.md: authoritative Claude policy (must-read)
+- Per-directory memory (optional, keep minimal and purposeful):
+  - crates/acp-lazy-core/CLAUDE.md — crate-specific build/test notes and links
+  - crates/codex-cli-acp/CLAUDE.md — protocol/adapter focus and test notes
+  - scripts/CLAUDE.md — how to use SDD scripts safely (no secrets), common flows
 
 Team Development Workflow for Claude Code
 - Source of tasks: dev-docs/plan/issues/* (issue-list with design, references, acceptance criteria)

--- a/WARP.md
+++ b/WARP.md
@@ -102,6 +102,7 @@ Communication
 References
 - Authority: CONTRIBUTING.md, sdd-rules/spec-driven.md, sdd-rules/lifecycle.md, sdd-rules/AGENTS.md
 - SDD templates: sdd-rules/spec-template.md, sdd-rules/plan-template.md, sdd-rules/tasks-template.md
+- SDD rules index: sdd-rules/rules/README.md
 - SDD commands: sdd-rules/commands/specify.md, sdd-rules/commands/plan.md, sdd-rules/commands/tasks.md
 - Project references: dev-docs/references/, dev-docs/references/acp_adapters/, dev-docs/references/cli_agents/, dev-docs/references/acp.md, dev-docs/references/zed_ide.md
 - Design/Plan/Requirements: dev-docs/design/, dev-docs/plan/, dev-docs/requirements/

--- a/crates/acp-lazy-core/CLAUDE.md
+++ b/crates/acp-lazy-core/CLAUDE.md
@@ -1,0 +1,15 @@
+# CLAUDE.md (crates/acp-lazy-core)
+
+Authority
+- See ../../sdd-rules/CLAUDE.md and ../../sdd-rules/AGENTS.md
+
+What to do here
+- Build/test this crate as part of workspace gates:
+  - cargo fmt --all -- --check
+  - cargo clippy --workspace --all-targets --all-features -- -D warnings
+  - cargo test --workspace --all-features --locked
+- Link evidence to dev-docs/review/_artifacts when adding tests/logs.
+
+Notes
+- Keep stdout clean; use stderr for logs when running protocol-related examples.
+

--- a/crates/codex-cli-acp/CLAUDE.md
+++ b/crates/codex-cli-acp/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md (crates/codex-cli-acp)
+
+Authority
+- See ../../sdd-rules/CLAUDE.md and ../../sdd-rules/AGENTS.md
+
+What to do here
+- Focus on ACP server/adapter behavior; keep stdout strictly JSONL in examples/tests
+- Build/test as part of workspace gates:
+  - cargo fmt --all -- --check
+  - cargo clippy --workspace --all-targets --all-features -- -D warnings
+  - cargo test --workspace --all-features --locked
+- Place JSONL replay scenarios under dev-docs/review/_artifacts/tests and logs under dev-docs/review/_artifacts/logs
+
+Notes
+- Use sdd-rules/commands/* to create/maintain spec/plan/tasks artifacts for new features.
+

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,18 @@
+# CLAUDE.md (scripts/)
+
+Authority
+- See ../sdd-rules/CLAUDE.md and ../sdd-rules/AGENTS.md
+
+Scripts overview
+- ci/: CI helpers (SDD structure lint, language policy)
+- sdd/: SDD document checks (language, lint_docs, semantic checks)
+- setup-plan.sh: bootstrap a new feature plan/specs using templates
+- common.sh, get-feature-paths.sh: shared utilities
+
+Usage
+- Do not echo secrets; pass via environment variables
+- Prefer non-interactive, non-paged commands
+
+References
+- sdd-rules/commands/specify.md, sdd-rules/commands/plan.md, sdd-rules/commands/tasks.md
+

--- a/sdd-rules/AGENTS.md
+++ b/sdd-rules/AGENTS.md
@@ -67,6 +67,7 @@ References
 - CONTRIBUTING.md
 - sdd-rules/lifecycle.md
 - sdd-rules/spec-template.md, sdd-rules/plan-template.md, sdd-rules/tasks-template.md
+- rules index: rules/README.md
 
 ---
 

--- a/sdd-rules/rules/README.md
+++ b/sdd-rules/rules/README.md
@@ -1,0 +1,35 @@
+# SDD Rules Index
+
+This index links to the baseline SDD rules for the Developer Team AI Engineers.
+
+- changelog
+  - rules/changelog/keep-a-changelog-index.html.haml
+  - rules/changelog/sdd-rules-changelog.md
+  - rules/changelog/semver.md
+- ci
+  - rules/ci/sdd-rules-ci.md
+- code-analysis
+  - rules/code-analysis/sdd-rules-code-analysis.md
+- documentation-style
+  - rules/documentation-style/Google-developer-documentation-style-guide.md
+  - rules/documentation-style/markdownlint-config.md
+  - rules/documentation-style/sdd-rules-documentation-style.md
+- git
+  - rules/git/comments/sdd-rules-comments.md
+  - rules/git/issues/sdd-rules-issues.md
+  - rules/git/pr/sdd-rules-pr.md
+  - rules/git/worktree/sdd-rules-worktrees.md
+- resaerch
+  - rules/resaerch/sdd-rules-resaerch.md
+- tests
+  - rules/tests/sdd-rules-tests.md
+- tools-cli
+  - rules/tools-cli/sdd-rules-tools-cli.md
+- tools-mcp
+  - rules/tools-mcp/sdd-rules-tools-mcp.md
+
+References
+- sdd-rules/AGENTS.md (authoritative agent rules)
+- sdd-rules/lifecycle.md (authoritative lifecycle)
+- WARP.md (repository agent operations)
+


### PR DESCRIPTION
## Summary\n- Add sdd-rules/rules/README.md (rules index)\n- Link rules index from sdd-rules/AGENTS.md and WARP.md\n- Update root CLAUDE.md: SDD navigation (scripts/specs/dev-docs/issues/review/_artifacts + Issues), memory layering\n- Add per-directory CLAUDE.md: crates/*, scripts/\n\n## Checks\n- Docs only; SDD lint & language policy should pass\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 文档
  - 将根级 CLAUDE.md 重组为仓库级 Claude Code 指南，补充治理、流程、ACP 协议与开发命令、质量门等内容。
  - 新增多处 CLAUDE.md（acp-lazy-core、codex-cli-acp、scripts）阐明构建/测试规范、日志与工件位置、stdout/stderr 约定与脚本使用指南。
  - 新增 SDD 规则索引 sdd-rules/rules/README.md，并在 WARP.md 与 sdd-rules/AGENTS.md 补充引用链接。
  - 完善团队工作流、测试策略与对齐参考，强化仓库级一致性。
- 其他
  - 无代码或公开 API 变更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->